### PR TITLE
Add "beta site" banner

### DIFF
--- a/_includes/beta-banner.html
+++ b/_includes/beta-banner.html
@@ -2,7 +2,7 @@
     <div class="usa-alert usa-alert--warning usa-alert--no-icon">
       <div class="usa-alert__body">
         <p class="usa-alert__text">
-        <strong>BETA SITE:</strong> We are testing new site for the the dotgov registrar. 
+        <strong>BETA SITE:</strong> We are testing a new site for the the dotgov registrar. 
         This site is for testing purposes only.
         </p>
       </div>

--- a/_includes/beta-banner.html
+++ b/_includes/beta-banner.html
@@ -2,7 +2,7 @@
     <div class="usa-alert usa-alert--warning usa-alert--no-icon">
       <div class="usa-alert__body">
         <p class="usa-alert__text">
-        <strong>BETA SITE:</strong> We are testing a new site for the dotgov registrar. 
+        <strong>BETA SITE:</strong> We are testing a new site for the .gov registrar. 
         This site is for testing purposes only.
         </p>
       </div>

--- a/_includes/beta-banner.html
+++ b/_includes/beta-banner.html
@@ -1,0 +1,11 @@
+<section aria-label="Alert" >
+    <div class="usa-alert usa-alert--warning usa-alert--no-icon">
+      <div class="usa-alert__body">
+        <p class="usa-alert__text">
+        <strong>BETA SITE:</strong> We are testing new site for the the dotgov registrar. 
+        This site is for testing purposes only.
+        </p>
+      </div>
+    </div>
+</section>
+

--- a/_includes/beta-banner.html
+++ b/_includes/beta-banner.html
@@ -2,7 +2,7 @@
     <div class="usa-alert usa-alert--warning usa-alert--no-icon">
       <div class="usa-alert__body">
         <p class="usa-alert__text">
-        <strong>BETA SITE:</strong> We are testing a new site for the the dotgov registrar. 
+        <strong>BETA SITE:</strong> We are testing a new site for the dotgov registrar. 
         This site is for testing purposes only.
         </p>
       </div>

--- a/_includes/layouts/base.html
+++ b/_includes/layouts/base.html
@@ -10,6 +10,7 @@ The home page uses wide.html layout, since it extends full width of page
 {% include "meta.html" %}
 
 <body>
+  {% include "beta-banner.html" %}
   {% include "header.html" %}
 
   {% include "menu.html" primary_navigation: site.primary_navigation secondary_navigation: site.secondary_navigation %}


### PR DESCRIPTION
This PR adds a banner to the top of the site to indicate that this is a beta site to be used for testing. 

👓 [Preview](https://federalist-877ab29f-16f6-4f12-961c-96cf064cf070.sites.pages.cloud.gov/preview/cisagov/getgov-home/ik/add-beta-banner/)

![image](https://user-images.githubusercontent.com/52677065/212430587-51222fb7-681f-43cf-89d1-d7c94eebff51.png)
