### PR TITLE
Add sorting and conditional formatting for landing pages

### DIFF
--- a/_includes/layouts/info-page.html
+++ b/_includes/layouts/info-page.html
@@ -3,7 +3,7 @@ layout: layouts/base
 ---
 
 {% comment %}
-This template is for landing pages
+This template is for longer information pages
 {% endcomment %}
 
 <div class="usa-layout-docs" >
@@ -14,6 +14,7 @@ This template is for landing pages
         {% include "sidenav.html" with collection %}
       {% endif %}
       <main id="main-content"class="usa-layout-docs__main desktop:grid-col-9 usa-prose margin-top-neg-1">
+        <h1>{{- title -}} </h1>
         {{ content }}
       </main>
     </div>

--- a/_includes/layouts/landing.html
+++ b/_includes/layouts/landing.html
@@ -47,7 +47,7 @@ This template is for landing pages
                 {% else %}
                 {% endif %}
               > 
-              <a href= {{ item.url }}>
+              <a href= {{ item.url | url }}>
                 <h3 class="margin-bottom-1 margin-top-0 text-primary">
                    {{ item.data.title }}
                 </h3>

--- a/_includes/layouts/landing.html
+++ b/_includes/layouts/landing.html
@@ -36,8 +36,9 @@ This template is for landing pages
       <main id="main-content"class="usa-layout-docs__main desktop:grid-col-9 usa-prose margin-top-neg-1">
         {{ content }}
         <section class="landing__index"> 
-          <ul class="grid-row grid-gap">
-          {%- for item in collections[tags[0]] | sort "data.eleventyNavigation.order" -%}
+        <ul class="grid-row grid-gap">
+          {% assign collection = collections[tags[0]] | sort: 'data.eleventyNavigation.order' %}
+          {%- for item in collection -%}
           {% if item.url == page.url %} {% continue %} {% endif %}
             <li class="tablet:grid-col-6 padding-left-0">
               <div 

--- a/_includes/layouts/landing.html
+++ b/_includes/layouts/landing.html
@@ -31,22 +31,28 @@ This template is for landing pages
   <div class="grid-container margin-top-5">
     <div class="grid-row grid-gap">
       {% if sidenav == true %}
-        {% assign collection = collections[tags] %}
-        {% include "sidenav.html" with collection %}
+        {% include "sidenav.html" %}
       {% endif %}
       <main id="main-content"class="usa-layout-docs__main desktop:grid-col-9 usa-prose margin-top-neg-1">
         {{ content }}
         <section class="landing__index"> 
           <ul class="grid-row grid-gap">
-          {%- for item in collections[tags] -%}
+          {%- for item in collections[tags[0]] | sort "data.eleventyNavigation.order" -%}
           {% if item.url == page.url %} {% continue %} {% endif %}
             <li class="tablet:grid-col-6 padding-left-0">
-              <div class="border-1px radius-md border-primary-light padding-105"> 
-                <h3 class="margin-bottom-1 margin-top-0">
-                  <a href= {{ item.url }}> {{ item.data.title }}</a>
+              <div 
+                {% if outlined_links %}
+                class="border-1px radius-md border-primary-light padding-105"
+                {% else %}
+                {% endif %}
+              > 
+              <a href= {{ item.url }}>
+                <h3 class="margin-bottom-1 margin-top-0 text-primary">
+                   {{ item.data.title }}
                 </h3>
+              </a>
                 {% if item.data.excerpt %}
-                  <p class="margin-top-0 margin-bottom-1"> {{- item.data.excerpt -}} </p>
+                  <p class="margin-top-0 margin-bottom-1 text-ink"> {{- item.data.excerpt -}} </p>
                 {% endif %}
                 </div>
             </li>

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -6,13 +6,7 @@ _layouts/page.html layout template, or you can add "sidenav: true" in the front-
 <aside class="usa-layout-docs-sidenav desktop:grid-col-3 padding-bottom-4">
   <nav>
     <ul class="usa-sidenav">
-      {% assign keyName = eleventyNavigation.key %}
-      ---
-      {% assign w = collections[eleventyNavigation.key] | sort: "data.eleventyNavigation.order" %}
-      {% for p in w %} {{p.data.title}} : {{p.data.eleventyNavigation.order}} {% endfor%}
-       "hi"
       {% assign links = collections[eleventyNavigation.key] | eleventyNavigation %}
-      {% assign links2 = collections[tags] %}
       {% for link in links %}
         {% assign _current = false %}
         {% if link.url == page.url %}

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -13,7 +13,7 @@ _layouts/page.html layout template, or you can add "sidenav: true" in the front-
           {% assign _current = true %}
         {% endif %}
         <li class="usa-sidenav__item">
-          <a href="{{ link.url }}"
+          <a href="{{ link.url | url }}"
              {% if _current %} class="usa-current" {% endif %}
           >
            {{ link.title }}

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -6,7 +6,14 @@ _layouts/page.html layout template, or you can add "sidenav: true" in the front-
 <aside class="usa-layout-docs-sidenav desktop:grid-col-3 padding-bottom-4">
   <nav>
     <ul class="usa-sidenav">
-      {% for link in collection %}
+      {% assign keyName = eleventyNavigation.key %}
+      ---
+      {% assign w = collections[eleventyNavigation.key] | sort: "data.eleventyNavigation.order" %}
+      {% for p in w %} {{p.data.title}} : {{p.data.eleventyNavigation.order}} {% endfor%}
+       "hi"
+      {% assign links = collections[eleventyNavigation.key] | eleventyNavigation %}
+      {% assign links2 = collections[tags] %}
+      {% for link in links %}
         {% assign _current = false %}
         {% if link.url == page.url %}
           {% assign _current = true %}
@@ -15,7 +22,7 @@ _layouts/page.html layout template, or you can add "sidenav: true" in the front-
           <a href="{{ link.url }}"
              {% if _current %} class="usa-current" {% endif %}
           >
-           {{ link.data.title }}
+           {{ link.title }}
           </a>
         </li>
     {% endfor %}

--- a/pages/domains/domains_benefits.md
+++ b/pages/domains/domains_benefits.md
@@ -3,11 +3,12 @@ title: Benefits of .gov domains
 permalink: /get-gov/benefits/
 layout: layouts/info-page
 sidenav: true
-tags: domains
 excerpt: Learn about the benefits of getting a .gov domain
+tags: domains
 eleventyNavigation:
   key: domains
   order: 2
+  title: Benefits of .gov domains 
 ---
 
 # Benefits of .gov domains

--- a/pages/get-gov.md
+++ b/pages/get-gov.md
@@ -3,9 +3,11 @@ title: Get a .gov
 permalink: /get-gov/
 layout: layouts/landing
 sidenav: true
+outlined_links: true
 tags: domains
 eleventyNavigation:
   key: domains
+  title: Get a .gov
   order: 1
 ---
 Introduction to getting a dotgov

--- a/pages/help/help_getstarted.md
+++ b/pages/help/help_getstarted.md
@@ -2,16 +2,16 @@
 title: Get Started
 permalink: /help/getstarted/
 layout: layouts/info-page
-tags: help
 searchbox: true
+tags: help
 eleventyNavigation:
   key: help
   order: 2
 ---
-Help page what's the problem?
 
-## Request a free .gov domain 
+## How to get started 
+Content content 
 
-<button class="usa-button">Start a request </button>
+
 
 

--- a/pages/help/help_getstarted.md
+++ b/pages/help/help_getstarted.md
@@ -6,7 +6,7 @@ searchbox: true
 tags: help
 eleventyNavigation:
   key: help
-  order: 2
+  order: 1 
 ---
 
 ## How to get started 

--- a/pages/help/help_index.md
+++ b/pages/help/help_index.md
@@ -8,10 +8,5 @@ eleventyNavigation:
   key: help
   order: 1
 ---
-Help page
 
-## Request a free .gov domain 
-
-<button class="usa-button">Start a request </button>
-
-
+## Topics

--- a/pages/help/help_signin.md
+++ b/pages/help/help_signin.md
@@ -1,0 +1,20 @@
+---
+title: Trouble signing in?
+permalink: /help/trouble-signing-in/
+layout: layouts/info-page
+searchbox: true
+excerpt: Troublshooting sign in issues
+tags: help
+eleventyNavigation:
+  key: help
+  order: 3
+  title: Trouble signing in?
+---
+
+
+## How to sign in
+Sign in
+
+
+
+


### PR DESCRIPTION
## ✍️ Changes proposed in this pull request

This PR is a continuation of the work started in #17. It adds logic for styling landing pages, to determine the group of links is styled with an outline or without. This option can be set in on a landing page's frontmatter by setting `outlined_links` to `true`. A few placeholder help pages have been added to test it out.

Additionally the PR fixes up the ordering of link on a landing page and in the sidebar.  

👓 [Preview](https://federalist-877ab29f-16f6-4f12-961c-96cf064cf070.sites.pages.cloud.gov/preview/cisagov/getgov-home/ik/setup-help-page/)
