### PR TITLE
Update main nav

### DIFF
--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -23,7 +23,7 @@ primary_navigation:
   - name: Help
     url: /help
   - name: News
-    url: /news/1
+    url: /news
   - name: About
     url: /about
 

--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -18,10 +18,8 @@ ga:
 primary_navigation:
   - name: Home
     url: /
-  - name: Get a .gov
-    url: /get-gov
-  - name: Manage your domain
-    url: /manage-domain
+  - name: Domains
+    url: /domains
   - name: Help
     url: /help
   - name: News

--- a/_includes/layouts/post.html
+++ b/_includes/layouts/post.html
@@ -10,7 +10,7 @@ This is used in blog/news posts. The index page can be found at news/index.html
   <div class="grid-container">
     <div class="grid-row grid-gap">
       <div class="post__back tablet:grid-col-2 margin-bottom-2"> 
-        <a href="/news/1" class="display-flex flex-align-center"> 
+        <a href="/news/" class="display-flex flex-align-center"> 
           {% uswds_icon 'arrow_back' %} <span class="margin-left-05"> Back to news </span></a>
       </div>
       <div class="usa-layout-docs__main tablet:grid-col-8 margin-top-neg-05 usa-prose">

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -50,7 +50,9 @@ manage your navigation system {% endcomment %}
           </ul>
         </li>
         {% endunless %} {% endfor %}
-        {% include "searchgov/form.html" searchgov: site.searchgov %}
+        <div class="margin-left-auto flex-align-self-center">
+          {% include "searchgov/form.html" searchgov: site.searchgov %}
+        </div>
       </ul>
       <div class="usa-nav__secondary">
         <ul class="usa-nav__secondary-links">
@@ -62,8 +64,8 @@ manage your navigation system {% endcomment %}
           </li>
           {% endfor %}
         </ul>
-        <a class="usa-button usa-button--outline" href="https://getgov-staging.app.cloud.gov/openid/login">
-          {% uswds_icon "login" %} Sign in
+        <a class="usa-button usa-button--outline margin-right-2" href="https://getgov-staging.app.cloud.gov/openid/login">
+          Manage your domains
         </a>
       </div>
     </div>

--- a/_includes/news-preview.html
+++ b/_includes/news-preview.html
@@ -13,4 +13,4 @@
   </li>
   {% endfor %}
 </ul>
-<a class="usa-link" href="/news/1">More news posts</a>
+<a class="usa-link" href="/news/">More news posts</a>

--- a/pages/domains/domains_index.md
+++ b/pages/domains/domains_index.md
@@ -1,13 +1,13 @@
 ---
-title: Get a .gov
-permalink: /get-gov/
+title: Domains
+permalink: /domains/
 layout: layouts/landing
 sidenav: true
 outlined_links: true
 tags: domains
 eleventyNavigation:
   key: domains
-  title: Get a .gov
+  title: Domains
   order: 1
 ---
 ## Request a free .gov domain 

--- a/pages/news/index.html
+++ b/pages/news/index.html
@@ -1,12 +1,12 @@
 ---
 layout: layouts/wide
 title: News
+permalink: "/news/{%if pagination.pageNumber > 0 %}{{pagination.pageNumber | plus:1 }}/{% endif %}"
 pagination:
   data: collections.posts
   size: 8
   alias: posts
   reverse: true
-permalink: "/news/{{pagination.pageNumber | plus:1 }}/"
 ---
 <section class="page-header bg-primary-lightest"> 
   <div class="grid-container padding-4">

--- a/styles/_uswds-theme-custom-styles.scss
+++ b/styles/_uswds-theme-custom-styles.scss
@@ -107,10 +107,6 @@ HEADER
   color: color('primary-darkest');
 }
 
-.usa-nav__inner .usa-search {
-  align-self: center;
-}
-
 .usa-nav__inner .usa-search button {
   background-color: color('primary');
 }


### PR DESCRIPTION
## ✍️ Changes proposed in this pull request

This PR updates the navigation to more closely match with the mockups and our decisions around the "Manage your domains" button and language. This is, the top right button should say "Manage your domains", and we should not include that semi-external link in the main navigation.

Similarly, we have discussed renaming "Get a .gov" to avoid confusion with the button on the home page, and @michelle-rago has suggesting renaming this index page to just "Domains."

Additionally this PR changes the permalinks for the news posts such that the first page no longer is `/new/1/`, but instead is just `/news/`

Also a slight style adjustment to align the search bar on the right. 

👓 [Preview](https://federalist-877ab29f-16f6-4f12-961c-96cf064cf070.sites.pages.cloud.gov/preview/cisagov/getgov-home/ik/update-nav/)
