### PR TITLE
Update tagline text

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -6,9 +6,9 @@ This will be displayed on the homepage. Ideally, you want to highlight key goals
   <div class="grid-container">
     <div class="hero-image">
       <h1 class="hero-heading hero-heading__callout">
-        It should be easy to identify governments on the internet.
+        It should be easy to identify governments on the internet
       </h1>
-      <h2 class="hero-heading hero-heading__content">.gov is the top-level domain for U.S.-based government organizations.</h2>
+      <h2 class="hero-heading hero-heading__content">.gov is the top-level domain for U.S. government organizations</h2>
     
       <a class="usa-button" href="/get-gov">Get a .gov</a>
       <a class="usa-button usa-button--outline" href="https://getgov-staging.app.cloud.gov/register">Manage your domain</a>


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove periods after headings
- Remove "-based" from "U.S.-based government organizations." I know we use this phrase elsewhere, but I'd like to remove "-based" when it's used in a heading.
