### PR TITLE
Rename get-gov permalink to domains

### DIFF
--- a/pages/about/about_index.md
+++ b/pages/about/about_index.md
@@ -38,7 +38,7 @@ We manage the authoritative record of all .gov domain names and their registrant
 
 - Using multi-factor authentication for all accounts in our domain registration and management system
 - Preloading all new domains. This action requires browsers to use a secure HTTPS connection with your website. This ensures that the content you publish is exactly what your visitors get.
-- Administering our [domain requirements](domains_requirements.md) to protect the integrity of .gov
+- Administering our [domain requirements](../domains/requirements) to protect the integrity of .gov
 - Publishing the [complete list of .gov domains](#)
 - Recommending [security best practices](#) for .gov domain holders
 - Continuously improving how we secure the .gov namespace
@@ -48,7 +48,7 @@ Follow our [product strategy and development activities on GitHub](https://githu
 ## What we offer
 
 ### Domain registration
-[Request your .gov now](#) or learn about the [information you'll need to complete your request](domain_benefits.md).
+[Request your .gov now](#) or learn about the [information you'll need to complete your request](../domains/before).
 
 ### Domain name consultation
 

--- a/pages/domains/domains_before.md
+++ b/pages/domains/domains_before.md
@@ -1,6 +1,6 @@
 ---
 title: Before you request a .gov domain
-permalink: /get-gov/before-you-request-a-dotgov-domain/
+permalink: /domains/before-you-request-a-dotgov-domain/
 layout: layouts/info-page
 sidenav: true
 excerpt: Follow these steps to complete your request as quickly as possible

--- a/pages/domains/domains_before.md
+++ b/pages/domains/domains_before.md
@@ -1,6 +1,6 @@
 ---
 title: Before you request a .gov domain
-permalink: /domains/before-you-request-a-dotgov-domain/
+permalink: /domains/before/
 layout: layouts/info-page
 sidenav: true
 excerpt: Follow these steps to complete your request as quickly as possible

--- a/pages/domains/domains_benefits.md
+++ b/pages/domains/domains_benefits.md
@@ -36,7 +36,7 @@ Only U.S.-based government organizations are eligible for .gov domains. This inc
 .Gov domains support access to public services. We make .gov a trusted, secure space by:
 - Using multi-factor authentication for all accounts in our domain registration and management system
 - Preloading all new domains. This action requires browsers to use a secure HTTPS connection with your website. This ensures that the content you publish is exactly what your visitors get.
-- Administering our [domain requirements](domains_requirements.md) to protect the integrity of .gov
+- Administering our [domain requirements](../requirements) to protect the integrity of .gov
 - Publishing the [complete list of .gov domains](#)
 - Recommending [security best practices](#) for .gov domain holders
 - Continuously improving how we secure the .gov namespace
@@ -44,7 +44,7 @@ Only U.S.-based government organizations are eligible for .gov domains. This inc
 ## What we offer
 
 ### Domain registration
-[Request your .gov now](#) or learn about the [information you'll need to complete your request](domain_benefits.md).
+[Request your .gov now](#) or learn about the [information you'll need to complete your request](../benefits).
 
 ### Domain name consultation
 

--- a/pages/domains/domains_benefits.md
+++ b/pages/domains/domains_benefits.md
@@ -1,6 +1,6 @@
 ---
 title: Benefits of .gov domains
-permalink: /get-gov/benefits/
+permalink: /domains/benefits/
 layout: layouts/info-page
 sidenav: true
 excerpt: Learn about the benefits of .gov domains

--- a/pages/domains/domains_choosing.md
+++ b/pages/domains/domains_choosing.md
@@ -1,6 +1,6 @@
 ---
 title: Choosing your .gov domain name
-permalink: /get-gov/choosing/
+permalink: /domains/choosing/
 layout: layouts/info-page
 sidenav: true
 excerpt: Requirements and tips for .gov domain names

--- a/pages/domains/domains_election.md
+++ b/pages/domains/domains_election.md
@@ -1,6 +1,6 @@
 ---
 title: .Gov for election offices
-permalink: /get-gov/election-offices/
+permalink: /domains/election-offices/
 layout: layouts/info-page
 sidenav: true
 excerpt: The .gov basics for election offices

--- a/pages/domains/domains_eligibility.md
+++ b/pages/domains/domains_eligibility.md
@@ -1,6 +1,6 @@
 ---
 title: Eligibility for .gov domains
-permalink: /get-gov/eligibility/
+permalink: /domains/eligibility/
 layout: layouts/info-page
 sidenav: true
 excerpt: Find out if your organization is eligible for a .gov domain

--- a/pages/domains/domains_moving.md
+++ b/pages/domains/domains_moving.md
@@ -1,6 +1,6 @@
 ---
 title: Moving to .gov
-permalink: /get-gov/moving/
+permalink: /domains/moving/
 layout: layouts/info-page
 sidenav: true
 excerpt: Tips for moving to .gov from another top-level domain (like .com or .us)

--- a/pages/domains/domains_requirements.md
+++ b/pages/domains/domains_requirements.md
@@ -1,6 +1,6 @@
 ---
 title: Requirements for operating .gov domains
-permalink: /get-gov/requirements/
+permalink: /domains/requirements/
 layout: layouts/info-page
 sidenav: true
 excerpt: What you can and can’t do with .gov domains

--- a/pages/domains/domains_security.md
+++ b/pages/domains/domains_security.md
@@ -1,6 +1,6 @@
 ---
 title: Domain security best practices
-permalink: /get-gov/security/
+permalink: /domains/security/
 layout: layouts/info-page
 sidenav: true
 excerpt: Domain security best practices for .gov domain managers


### PR DESCRIPTION
## ✍️ Changes proposed in this pull request:
This PR updates permalinks for the domains collection to use `/domains/` instead of `/get-gov/` to more accurately reflect the name. Also fixes a few broken links.


