### PR TITLE
Content blocks and links fixes

### DIFF
--- a/_includes/content-blocks/org_types.md
+++ b/_includes/content-blocks/org_types.md
@@ -1,0 +1,8 @@
+- **Federal**: an agency of the U.S. government's executive, legislative, or judicial branches
+- **Interstate**: an organization of two or more states
+- **State or territory**: one of the 50 U.S. states, the District of Columbia, American Samoa, Guam, Northern Mariana Islands, Puerto Rico, or the U.S. Virgin Islands
+- **Tribal**: a tribal government recognized by the federal or a state government
+- **County**: a county, parish, or borough
+- **City**: a city, town, township, village, etc.
+- **Special district**: an independent organization within a single state
+- **School district**: a school district that is not part of a local government

--- a/pages/domains/domains_before.md
+++ b/pages/domains/domains_before.md
@@ -46,14 +46,8 @@ We’ll ask you questions about your organization and the domain you want. Here�
 ### Type of government organization you represent
 
 You’ll choose from the list below. [Read more about these types](#) if you’re not sure which is right for you.
-- **Federal**: an agency of the U.S. government's executive, legislative, or judicial branches
-- **Interstate**: an organization of two or more states
-- **State or territory**: one of the 50 U.S. states, the District of Columbia, American Samoa, Guam, Northern Mariana Islands, Puerto Rico, or the U.S. Virgin Islands
-- **Tribal**: a tribal government recognized by the federal or a state government
-- **County**: a county, parish, or borough
-- **City**: a city, town, township, village, etc.
-- **Special district**: an independent organization within a single state
-- **School district**: a school district that is not part of a local government
+
+{% include 'content-blocks/org_types.md' %}
 
 ### Organization name and mailing address
 

--- a/pages/domains/domains_eligibility.md
+++ b/pages/domains/domains_eligibility.md
@@ -20,15 +20,8 @@ The Cybersecurity and Infrastructure Security Agency (CISA) manages the .gov top
 
 ## Government organizations at all levels are eligible for .gov domains
 If you’re eligible to have a .gov domain we want you to get one. The types of government organizations eligible for .gov domains include:
-- **Federal**: an agency of the U.S. government's executive, legislative, or judicial branches
-- **Interstate**: an organization of two or more states
-- **State or territory**: one of the 50 U.S. states, the District of Columbia, American Samoa, Guam, Northern Mariana Islands, Puerto Rico, or the U.S. Virgin Islands
-- **Tribal**: a tribal government recognized by the federal or a state government
-- **County**: a county, parish, or borough
-- **City**: a city, town, township, village, etc.
-- **Special district**: an independent organization within a single state
-- **School district**: a school district that is not part of a local government
 
+{% include 'content-blocks/org_types.md' %}
 
 ## How we determine eligibility
 After you request a .gov domain, we'll review the information you provided about your organization. We use the [U.S. Census Bureau’s criteria for classifying governments](https://www.census.gov/programs-surveys/gus/technical-documentation/methodology/population-of-interest1.html) to help determine eligibility. In some cases, we'll request more information (such as legislation, a charter, or bylaws) to verify eligibility.

--- a/pages/help/help_domain-requests.md
+++ b/pages/help/help_domain-requests.md
@@ -29,14 +29,7 @@ Follow these steps to complete your request as quickly as possible.
 
 Government organizations at all levels are eligible for .gov domains. These include:
 
-- **Federal**: an agency of the U.S. government's executive, legislative, or judicial branches
-- **Interstate**: an organization of two or more states
-- **State or territory**: one of the 50 U.S. states, the District of Columbia, American Samoa, Guam, Northern Mariana Islands, Puerto Rico, or the U.S. Virgin Islands
-- **Tribal**: a tribal government recognized by the federal or a state government
-- **County**: a county, parish, or borough
-- **City**: a city, town, township, village, etc.
-- **Special district**: an independent organization within a single state
-- **School district**: a school district that is not part of a local government
+{% include 'content-blocks/org_types.md' %}
 
 After you request a .gov domain, we'll review the information you provided about your organization. We use the [U.S. Census Bureau’s criteria for classifying governments](https://www.census.gov/programs-surveys/gus/technical-documentation/methodology/population-of-interest1.html) to help determine eligibility. In some cases, we'll request more information (such as legislation, a charter, or bylaws) to verify eligibility.
 

--- a/styles/_uswds-theme-custom-styles.scss
+++ b/styles/_uswds-theme-custom-styles.scss
@@ -27,6 +27,7 @@ SITEWIDE
 
 // Temporary styling for undetermined links
 a[href="#"] {
+  color: color('blue-80v') !important;
   background-color: color('gold-10v') !important; 
   padding: 0 units(0.5);
 
@@ -90,7 +91,16 @@ h3 {
   }
 
   a {
-  color: color('primary');
+    color: color('primary');
+
+    &:hover, 
+    &:focus {
+      color: color('primary-darker');
+    }
+  }
+
+  .usa-link--external {
+    display: initial;
   }
 }
 


### PR DESCRIPTION
## ✍️  Changes proposed in this pull request:
This PR proposes an implementation of "content-blocks", repeated pieces of content that are used throughout the site. I am staring with the organization type lists, replacing any instance where that list is written out with an `include`. This method will allow us to edit the content in one place (as a markdown file under `/_includes/content-blocks`). If this approach works, we can apply it to other repeated pieces of content

Also rolled into this PR are fixes to link styles:
- Adding a hover and focus style
- Updating TBD link color so it's readable on dark backgrounds
- Fixing overlap issue for links in checklists

👓 [Preview](https://federalist-877ab29f-16f6-4f12-961c-96cf064cf070.sites.pages.cloud.gov/preview/cisagov/getgov-home/ik/reusable-content/) 