### PR TITLE
Change favicon references

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -32,11 +32,11 @@ to modify some of the meta-data for the site, this is the place to do it.
   <script async="" src="{{ assetPaths['uswds.js'] }} "></script>
   <!-- Favicon 
     ================================================== -->
-  <link rel="icon" type="image/png" sizes="32x32" href="/img/favicons/favicon-32.png">
-  <link rel="icon" type="image/png" sizes="192x192" href="/img/favicons/favicon-192.png">
-  <link rel="icon" type="image/svg+xml" href="img/favicons/favicon.svg">
-  <link rel="shortcut icon" type="image/x-icon" href= 'favicon.ico' />
-  <link rel="apple-touch-icon" sizes="180x180" href="/img/favicons/favicon-180.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="{{'/img/favicons/favicon-32.png' | url }}">
+  <link rel="icon" type="image/png" sizes="192x192" href="{{'/img/favicons/favicon-192.png' | url }}">
+  <link rel="icon" type="image/svg+xml" href="{{'/img/favicons/favicon.svg' | url }}">
+  <link rel="shortcut icon" type="image/x-icon" href="{{ '/favicon.ico' | url }}" />
+  <link rel="apple-touch-icon" sizes="180x180" href="{{'/img/favicons/favicon-180.png' | url }}">
   <!-- CSS
     ================================================== -->
     <link rel="preload" as="style" href="{{ assetPaths['styles.css'] }}" />


### PR DESCRIPTION
## ✍️  Changes proposed in this pull request:
Change favicon hrefs to be absolute using the  11ty `url` filter, because they otherwise the favicon didn't show up on pages beyond the home pages

Favicons are NP-hard

👓 [Preview](https://federalist-877ab29f-16f6-4f12-961c-96cf064cf070.sites.pages.cloud.gov/preview/cisagov/getgov-home/ik/favicon-ii/)

<img width="376" alt="image" src="https://user-images.githubusercontent.com/52677065/229235876-2e015fa3-3c9a-492c-ac01-4a4b60d8e54b.png">
<img width="370" alt="image" src="https://user-images.githubusercontent.com/52677065/229235979-a5e8cf8f-dd3f-4600-a64f-2fe3247b5aea.png">

