### PR TITLE
Remove autolinking and span workarounds

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -109,7 +109,7 @@ module.exports = function (config) {
   let markdownLibrary = markdownIt({
     html: true,
     breaks: true,
-    linkify: true,
+    linkify: false,
   }).use(markdownItAttrs).use(markdownItAnchor);
   config.setLibrary('md', markdownLibrary);
 

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -17,7 +17,7 @@ We’ll respond within one business day if a response is needed.
 
 ### Visit us on GitHub
 
-Report an issue with this website on the [get&#46;gov code repository on GitHub](https://github.com/cisagov/getgov-home).
+Report an issue with this website on the [get.gov code repository on GitHub](https://github.com/cisagov/getgov-home).
 
 ## Report a system vulnerability
 

--- a/pages/domains/domains_before.md
+++ b/pages/domains/domains_before.md
@@ -25,7 +25,7 @@ Complete your request as quickly as possible by taking these actions.{.checklist
 - **Domain name**: [Choose an available .gov domain that complies with our requirements](../choosing/).
 - **Authorizing official**: [Find out who your authorizing official is](../eligibility/#you-must-have-approval-from-an-authorizing-official-within-your-organization) and make sure they approve your request.
 - **Request form**: Gather [all the information you’ll need](#information-you’ll-need-to-complete-the-domain-request-form) to complete your domain request.
-- **Account**: [Create a Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}. You’ll need a Login.gov account to request a .gov domain. Login.gov provides a simple and secure process for signing into many government services with one account. [Read more about why we’re using Login&#46;gov](#).
+- **Account**: [Create a Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}. You’ll need a Login.gov account to request a .gov domain. Login.gov provides a simple and secure process for signing into many government services with one account. [Read more about why we’re using Login.gov](#).
 
 
 ## Completing the request form might take 15 minutes

--- a/pages/domains/domains_before.md
+++ b/pages/domains/domains_before.md
@@ -25,12 +25,12 @@ Complete your request as quickly as possible by taking these actions.{.checklist
 - **Domain name**: [Choose an available .gov domain that complies with our requirements](../choosing/).
 - **Authorizing official**: [Find out who your authorizing official is](../eligibility/#you-must-have-approval-from-an-authorizing-official-within-your-organization) and make sure they approve your request.
 - **Request form**: Gather [all the information you’ll need](#information-you’ll-need-to-complete-the-domain-request-form) to complete your domain request.
-- **Account**: [Create a Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}. You’ll need a Login<span>.gov</span> account to request a .gov domain. Login<span>.gov</span> provides a simple and secure process for signing into many government services with one account. [Read more about why we’re using Login&#46;gov](#).
+- **Account**: [Create a Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}. You’ll need a Login.gov account to request a .gov domain. Login.gov provides a simple and secure process for signing into many government services with one account. [Read more about why we’re using Login&#46;gov](#).
 
 
 ## Completing the request form might take 15 minutes
 
-If you have your Login<span>.gov</span> account and have gathered all the information you need, completing your domain request might take around 15 minutes.
+If you have your Login.gov account and have gathered all the information you need, completing your domain request might take around 15 minutes.
 
 
 ## Information you’ll need to complete the domain request form

--- a/pages/domains/domains_choosing.md
+++ b/pages/domains/domains_choosing.md
@@ -26,7 +26,7 @@ While internet domain names must be unique, names of government organizations ca
 
 
 ## Only federal agencies can request generic terms
-Only federal agencies can request generic terms like vote<span>.gov</span> or benefits<span>.gov</span>.
+Only federal agencies can request generic terms like vote.gov or benefits.gov.
 
 That said, we can approve domains with generic terms, like marylandvotes&#46;gov, because it references a location and a service.
 
@@ -55,33 +55,33 @@ Read domain name requirements and guidance for:
 These are agencies of the U.S. government's executive branch.
 
 Examples:
-- fema<span>.gov</span>
-- medicare<span>.gov</span>
-- usda<span>.gov</span>
+- fema.gov
+- medicare.gov
+- usda.gov
 
 ### Judicial branch federal agencies
 These are agencies of the U.S. government's judicial branch.
 
 Examples:
-- uscourts<span>.gov</span>
-- ustaxcourt<span>.gov</span>
-- ussc<span>.gov</span>
+- uscourts.gov
+- ustaxcourt.gov
+- ussc.gov
 
 ### Legislative branch federal agencies
 These are agencies of the U.S. government's legislative branch.
 
 Examples:
-- gao<span>.gov</span>
-- gpo<span>.gov</span>
-- loc<span>.gov</span>
+- gao.gov
+- gpo.gov
+- loc.gov
 
 ### Interstate organizations
 These are organizations of two or more states.
 
 Examples:
-- EMScompact<span>.gov</span>
-- wmataOIG<span>.gov</span>
-- trpa<span>.gov</span>
+- EMScompact.gov
+- wmataOIG.gov
+- trpa.gov
 
 
 ### U.S. states and territories
@@ -90,10 +90,10 @@ This includes the 50 U.S. states, the District of Columbia, American Samoa, Guam
 State .gov domains must include the two-letter state abbreviation or clearly spell out the state name. 
 
 Examples:
-- AmericanSamoa<span>.gov</span>
-- Coloradog<span>.gov</span>
-- Georgia<span>.gov</span>
-- Guam<span>.gov</span>
+- AmericanSamoa.gov
+- Coloradog.gov
+- Georgia.gov
+- Guam.gov
 
 ### Tribal governments
 Tribal governments recognized by the federal or a state government.
@@ -101,9 +101,9 @@ Tribal governments recognized by the federal or a state government.
 Tribal domains may include the suffix -nsn, for native sovereign nation.
 
 Examples:
-- tbyi<span>.gov</span>
-- pitu<span>.gov</span>
-- TulalipTribalCourt-nsn<span>.gov</span>
+- tbyi.gov
+- pitu.gov
+- TulalipTribalCourt-nsn.gov
 
 ### Counties
 This organization type includes counties, parishes, or boroughs.
@@ -111,10 +111,10 @@ This organization type includes counties, parishes, or boroughs.
 Most county .gov domains must include the two-letter state abbreviation or the full state name. County names that aren’t shared by any other city, county, parish, town, borough, village or equivalent in the U.S., at the time a domain is granted, can be requested without referring to the state. Counties can include “county” in their domain to distinguish it from other places with similar names. We use the [Census Bureau’s National Places Gazetteer Files](https://www.census.gov/geographies/reference-files/time-series/geo/gazetteer-files.html){.usa-link--external} to determine if county names are unique.
 
 Examples:
-- AdamsCountyMS<span>.gov</span>
-- LivingstonParishLA<span>.gov</span>
-- MitchellCountyNC<span>.gov</span>
-- Erie<span>.gov</span>
+- AdamsCountyMS.gov
+- LivingstonParishLA.gov
+- MitchellCountyNC.gov
+- Erie.gov
 
 ### Cities
 This organization type includes cities, towns, townships, villages, etc.
@@ -130,10 +130,10 @@ Some cities don’t have to refer to their state.
 - The 50 largest cities, as measured by population according to the Census Bureau, can have .gov domain names that don’t refer to their state.
 
 Examples:
-- CityofEudoraKS<span>.gov</span>
-- WallaWallaWA<span>.gov</span>
-- Pocatello<span>.gov</span>
-- nyc<span>.gov</span>
+- CityofEudoraKS.gov
+- WallaWallaWA.gov
+- Pocatello.gov
+- nyc.gov
 
 ### Special districts
 These are independent organizations within a single state.
@@ -141,11 +141,11 @@ These are independent organizations within a single state.
 Domain names must represent your organization or institutional name, not solely the services you provide. It also needs to include your two-letter state abbreviation or clearly spell out the state name unless city or county exceptions apply.
 
 Examples:
-- ElectionsShelbyTN<span>.gov</span>
-- GlacierViewFire<span>.gov</span>
-- HVcoVote<span>.gov</span>
-- TechshareTX<span>.gov</span>
-- UtahTrust<span>.gov</span>
+- ElectionsShelbyTN.gov
+- GlacierViewFire.gov
+- HVcoVote.gov
+- TechshareTX.gov
+- UtahTrust.gov
 
 ### School districts
 School districts that aren’t part of a local government are eligible for .gov domains.
@@ -153,7 +153,7 @@ School districts that aren’t part of a local government are eligible for .gov 
 Domain names must represent your organization or institutional name.
 
 Example:
-- mckinneyISDTX<span>.gov</span>
+- mckinneyISDTX.gov
 
 ## Check if your desired .gov domain is available
 Check to make sure your desired name hasn’t already been registered.

--- a/pages/domains/domains_choosing.md
+++ b/pages/domains/domains_choosing.md
@@ -28,7 +28,7 @@ While internet domain names must be unique, names of government organizations ca
 ## Only federal agencies can request generic terms
 Only federal agencies can request generic terms like vote.gov or benefits.gov.
 
-That said, we can approve domains with generic terms, like marylandvotes&#46;gov, because it references a location and a service.
+That said, we can approve domains with generic terms, like marylandvotes.gov, because it references a location and a service.
 
 
 ## Things to avoid in .gov domain names

--- a/pages/domains/domains_moving.md
+++ b/pages/domains/domains_moving.md
@@ -110,23 +110,23 @@ Many government organizations share the fact that they've transitioned to a .gov
 Here are some examples of government organizations communicating publicly about their move to .gov.
 
 ### Press releases
-- [Dallas, TX](https://www.dallascitynews.net/new-dallas-gov-domain-name){.usa-link--external} – dallas<span>.gov</span> 
-- [Colorado Secretary of State](https://wwwsos.state.co.us/pubs/newsRoom/pressReleases/2021/PR20210825Domain.html){.usa-link--external} – coloradosos<span>.gov</span>
-- [Larimer County, CO](https://www.larimer.gov/spotlights/2022/04/27/why-we-are-moving-larimergov){.usa-link--external} – larimer<span>.gov</span>
-- [Hillsborough County, FL](https://www.votehillsborough.gov/Portals/Hillsborough/Documents/Press%20Releases/2021%20Press%20Releases/New%20VoteHillsborough%20Web%20Address.pdf?ver=GXgWNkiPHgjV51lfuXIb2Q%3d%3d){.usa-link--external} – votehillsborough<span>.gov</span>
+- [Dallas, TX](https://www.dallascitynews.net/new-dallas-gov-domain-name){.usa-link--external} – dallas.gov 
+- [Colorado Secretary of State](https://wwwsos.state.co.us/pubs/newsRoom/pressReleases/2021/PR20210825Domain.html){.usa-link--external} – coloradosos.gov
+- [Larimer County, CO](https://www.larimer.gov/spotlights/2022/04/27/why-we-are-moving-larimergov){.usa-link--external} – larimer.gov
+- [Hillsborough County, FL](https://www.votehillsborough.gov/Portals/Hillsborough/Documents/Press%20Releases/2021%20Press%20Releases/New%20VoteHillsborough%20Web%20Address.pdf?ver=GXgWNkiPHgjV51lfuXIb2Q%3d%3d){.usa-link--external} – votehillsborough.gov
 
 ### Social media
 
-- [\@COSecofState](https://twitter.com/COSecofState/status/1430583619865616385){.usa-link--external} – coloradosos<span>.gov</span>
-- [\@ArlingtonVotes](https://twitter.com/ArlingtonVotes/status/1554158281135898625){.usa-link--external} – vote.arlingtonva<span>.gov</span>
-- [\@bouldercounty](https://twitter.com/bouldercounty/status/1545070920452096001){.usa-link--external} – bouldercounty<span>.gov</span>
-- [\@Carrboro, NC](https://twitter.com/CarrboroGov/status/1483845242071752711){.usa-link--external} – carrboronc<span>.gov</span>
+- [\@COSecofState](https://twitter.com/COSecofState/status/1430583619865616385){.usa-link--external} – coloradosos.gov
+- [\@ArlingtonVotes](https://twitter.com/ArlingtonVotes/status/1554158281135898625){.usa-link--external} – vote.arlingtonva.gov
+- [\@bouldercounty](https://twitter.com/bouldercounty/status/1545070920452096001){.usa-link--external} – bouldercounty.gov
+- [\@Carrboro, NC](https://twitter.com/CarrboroGov/status/1483845242071752711){.usa-link--external} – carrboronc.gov
 
 ### Print and radio
 
-- [Abilene Reflector-Chronicle](https://www.abilene-rc.com/news/county-website-and-emails-change-from-org-to-gov/article_cc417aaa-5ceb-11ec-80db-3b467491a717.html){.usa-link--external} – dickinsontexas<span>.gov</span>
-- [Missourian](https://www.emissourian.com/local_news/union-moving-to-gov-domain-name/article_4bc2bf98-62b2-11ec-bde9-e70c55cd93c4.html){.usa-link--external} – UnionMissouri<span>.gov</span>
-- [WJBC, AM 1230](https://www.wjbc.com/2022/04/29/bloomington-normal-to-update-website-domains/){.usa-link--external} - bloomingtonil<span>.gov</span>
+- [Abilene Reflector-Chronicle](https://www.abilene-rc.com/news/county-website-and-emails-change-from-org-to-gov/article_cc417aaa-5ceb-11ec-80db-3b467491a717.html){.usa-link--external} – dickinsontexas.gov
+- [Missourian](https://www.emissourian.com/local_news/union-moving-to-gov-domain-name/article_4bc2bf98-62b2-11ec-bde9-e70c55cd93c4.html){.usa-link--external} – UnionMissouri.gov
+- [WJBC, AM 1230](https://www.wjbc.com/2022/04/29/bloomington-normal-to-update-website-domains/){.usa-link--external} - bloomingtonil.gov
 
 ### Online and offline branding
 

--- a/pages/domains/domains_security.md
+++ b/pages/domains/domains_security.md
@@ -17,7 +17,7 @@ Domain management can ensure a safe experience for your users and your organizat
 
 A security email allows the public to report observed or suspected security issues on your domain. Security issues could include notifications about compromised accounts, unsolicited email, routing problems, or potential vulnerabilities. 
 
-Security emails are made public in the [.gov WHOIS](#) (including port 43) and in [our published data](../../about/data). A security contact should be capable of evaluating or triaging security reports for your entire domain. Use a team email address, not an individual’s email. We recommend using an alias, like security@domain<span>.gov</span>. 
+Security emails are made public in the [.gov WHOIS](#) (including port 43) and in [our published data](../../about/data). A security contact should be capable of evaluating or triaging security reports for your entire domain. Use a team email address, not an individual’s email. We recommend using an alias, like security@domain.gov. 
 
 Add your security contact to your website and in organizational communications so it’s easy for the public to know where to report issues.
 

--- a/pages/help/help_domain-requests.md
+++ b/pages/help/help_domain-requests.md
@@ -48,8 +48,8 @@ While internet domain names must be unique, names of government organizations ca
 - Be clear to the general public. Your domain name must not be easily confused with other organizations.
 
 #### Only federal agencies can request generic terms
-Only federal agencies can request generic terms like vote&#46;gov or benefits&#46;gov.
-That said, we can approve domains with generic terms, like marylandvotes&#46;gov, because it references a location and a service.
+Only federal agencies can request generic terms like vote.gov or benefits.gov.
+That said, we can approve domains with generic terms, like marylandvotes.gov, because it references a location and a service.
 
 
 #### Things to avoid in .gov domain names

--- a/pages/privacy-policy.md
+++ b/pages/privacy-policy.md
@@ -14,7 +14,7 @@ eleventyNavigation:
 
 We automatically collect and store the following information:
 
-- The name of the domain from which you access the internet (e.g., DHS.gov if you connect from a U.S. Department of Homeland Security account, or GMU<span>.edu</span> if you connect from George Mason University’s domain)
+- The name of the domain from which you access the internet (e.g., DHS.gov if you connect from a U.S. Department of Homeland Security account, or GMU.edu if you connect from George Mason University’s domain)
 - The date and time of your visit
 - The pages you visit on get.gov
 - Search terms that you enter into the get.gov search box

--- a/pages/privacy-policy.md
+++ b/pages/privacy-policy.md
@@ -8,18 +8,18 @@ eleventyNavigation:
   title: Privacy policy
 ---
   
-**We won't collect personal data about you unless you choose to provide it**. We only collect statistical information that helps us make get<span>.gov</span> better for all visitors.
+**We won't collect personal data about you unless you choose to provide it**. We only collect statistical information that helps us make get.gov better for all visitors.
 
 ## Information we collect
 
 We automatically collect and store the following information:
 
-- The name of the domain from which you access the internet (e.g., DHS<span>.gov</span> if you connect from a U.S. Department of Homeland Security account, or GMU<span>.edu</span> if you connect from George Mason University’s domain)
+- The name of the domain from which you access the internet (e.g., DHS.gov if you connect from a U.S. Department of Homeland Security account, or GMU<span>.edu</span> if you connect from George Mason University’s domain)
 - The date and time of your visit
-- The pages you visit on get<span>.gov</span>
-- Search terms that you enter into the get<span>.gov</span> search box
-- The internet address of the website you came from if it linked you directly to get<span>.gov</span> and if the referring website shares that information
-- If your browser accepts cookies, we may use a session cookie to learn how different visitors come to get<span>.gov</span>.
+- The pages you visit on get.gov
+- Search terms that you enter into the get.gov search box
+- The internet address of the website you came from if it linked you directly to get.gov and if the referring website shares that information
+- If your browser accepts cookies, we may use a session cookie to learn how different visitors come to get.gov.
 
 ## Information you send us
 

--- a/pages/vulnerability-disclosure-policy.md
+++ b/pages/vulnerability-disclosure-policy.md
@@ -49,17 +49,17 @@ The following test methods are not authorized:
 ## Systems and services covered by this policy
 
 This policy applies to the following systems and services:
-- get<span>.gov</span>
-- All subdomains of get<span>.gov</span> (like example.get<span>.gov</span>)
-- Source code at [https://github.com/cisagov/getgov](https://github.com/cisagov/getgov){.usa-link--external} (registrar application) and [https://github.com/cisagov/getgov-home](https://github.com/cisagov/getgov-home){.usa-link--external} (get<span>.gov</span> public website)
+- get.gov
+- All subdomains of get.gov (like example.get.gov)
+- Source code at [https://github.com/cisagov/getgov](https://github.com/cisagov/getgov){.usa-link--external} (registrar application) and [https://github.com/cisagov/getgov-home](https://github.com/cisagov/getgov-home){.usa-link--external} (get.gov public website)
 
-Any service not expressly listed above, such as any connected services, are excluded from scope and are not authorized for testing. And, vulnerabilities found in systems from our vendors fall outside of this policy’s scope and should be reported directly to the vendor according to their disclosure policy (if any). If you aren’t sure whether a system is in scope or not, email us at dotgov@cisa.dhs<span>.gov</span> before starting your research. Or, ask the security contact for the system’s domain name listed in the [.gov WHOIS](#).
+Any service not expressly listed above, such as any connected services, are excluded from scope and are not authorized for testing. And, vulnerabilities found in systems from our vendors fall outside of this policy’s scope and should be reported directly to the vendor according to their disclosure policy (if any). If you aren’t sure whether a system is in scope or not, email us at dotgov@cisa.dhs.gov before starting your research. Or, ask the security contact for the system’s domain name listed in the [.gov WHOIS](#).
 
 Though we develop and maintain other internet-accessible systems or services, we ask that active research and testing only be conducted on the systems and services covered by the scope of this document. If there is a particular system not in scope that you think merits testing, please contact us to discuss it first.
 
 ## How to report a vulnerability
 
-[Submit a vulnerability report using this form](https://docs.google.com/forms/d/e/1FAIpQLSeZQGRJWsOWydQh5JU-zKqdhkXYbrY1qReCaaYGoOg14fN2iA/viewform?usp=sf_link) or via dotgov@cisa.dhs<span>.gov</span>. You can submit a report anonymously. If you share contact information, we will acknowledge receipt of your report within three business days.
+[Submit a vulnerability report using this form](https://docs.google.com/forms/d/e/1FAIpQLSeZQGRJWsOWydQh5JU-zKqdhkXYbrY1qReCaaYGoOg14fN2iA/viewform?usp=sf_link) or via dotgov@cisa.dhs.gov. You can submit a report anonymously. If you share contact information, we will acknowledge receipt of your report within three business days.
 
 ### What to include in your vulnerability report
 
@@ -76,10 +76,10 @@ If you choose to share your contact information with us, we commit to coordinati
 - We’ll maintain an open dialogue to discuss issues.
 
 ## Other .gov systems and services
-If you find a security or privacy issue on another .gov service, check the [data for all .gov domains](../about/data/#all-.gov-domains) to see if the domain has a security contact. Most federal (executive branch) agencies also have a vulnerability disclosure policy. If you are unable to find a contact or receive no response from the security contact, email dotgov@cisa.dhs<span>.gov</span>.
+If you find a security or privacy issue on another .gov service, check the [data for all .gov domains](../about/data/#all-.gov-domains) to see if the domain has a security contact. Most federal (executive branch) agencies also have a vulnerability disclosure policy. If you are unable to find a contact or receive no response from the security contact, email dotgov@cisa.dhs.gov.
 
 ## Questions
-Questions regarding this policy may be sent to dotgov@cisa.dhs<span>.gov</span>.
+Questions regarding this policy may be sent to dotgov@cisa.dhs.gov.
 
 
 


### PR DESCRIPTION
## ✍️  Changes proposed in this pull request:
This PR turns off the automatic linking feature, and replaces where we used the `<span>` or html entity (i.e. `&#46;`) workarounds with a simple `.`.

As discussed we'll need to make sure any urls we actually want to be a hyperlink are manually linked 
👓 [Preview](https://federalist-877ab29f-16f6-4f12-961c-96cf064cf070.sites.pages.cloud.gov/preview/cisagov/getgov-home/ik/remove-autolink/)