### PR TITLE
Ignore asset paths for git

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -19,6 +19,9 @@ module.exports = function (config) {
   // Copy USWDS init JS so we can load it in HEAD to prevent banner flashing
   config.addPassthroughCopy({'./node_modules/@uswds/uswds/dist/js/uswds-init.js': 'assets/js/uswds-init.js'});
 
+  //assetPaths is in gitignore but we still want to watch for changes to build
+  config.watchIgnores.delete('_data/assetPaths.json');
+  
   // Add plugins
   config.addPlugin(pluginRss);
   config.addPlugin(pluginNavigation);

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ web_modules/
 _site
 public
 node_modules
+_data/assetPaths.json


### PR DESCRIPTION
## ✍️ Changes proposed in this pull request:
This PR adds the cache busting `assetPaths.json` to `.gitignore` while preserving it on the watch list in eleventy's build config. Since assetPaths changes on every save, it shows up on git's list of file change, but it doesn't make sense to commit it. 

