### PR TITLE
Added content blocks and updated instructions for domain changes

### DIFF
--- a/_includes/content-blocks/general_domain_requirements.md
+++ b/_includes/content-blocks/general_domain_requirements.md
@@ -1,0 +1,6 @@
+Your domain name must:
+
+- Be available ([Check availability](#))
+- Be unique
+- Relate to your organization’s name, location, and/or services
+- Be clear to the general public. Your domain name must not be easily confused with other organizations.

--- a/_includes/content-blocks/information_needed_for_domain_request.md
+++ b/_includes/content-blocks/information_needed_for_domain_request.md
@@ -1,0 +1,7 @@
+- Type of government organization you represent
+- Organization name and mailing address
+- Name, role, and contact information for your authorizing official
+- Purpose of the .gov domain
+- Current website for your organization (if you have one)
+- .Gov domain you want
+- Other employees from your organization

--- a/pages/domains/domains_before.md
+++ b/pages/domains/domains_before.md
@@ -40,7 +40,7 @@ If you have your [Login.gov](https://login.gov/){.usa-link--external} account an
 
 We’ll ask you questions about your organization and the domain you want. Here’s what you’ll need to know to complete the form. There’s more information about each of these sections below.
 
-{% include 'content-blocks/information_needed_for_domain_requests.md' %}
+{% include 'content-blocks/information_needed_for_domain_request.md' %}
 
 ### Type of government organization you represent
 

--- a/pages/domains/domains_before.md
+++ b/pages/domains/domains_before.md
@@ -76,11 +76,7 @@ We’ll ask about your organization’s current public website. We can better ev
 
 Here’s the part where you’ll tell us the .gov domain you want. We’ll try to give you your preferred domain. We first need to make sure your request meets our requirements. We’ll work with you to find the best domain for your organization.
 
-Your domain name must:
-- Be available ([Check availability](#))
-- Be unique
-- Relate to your organization’s name, location, and/or services
-- Be clear to the general public. Your domain name must not be easily confused with other organizations.
+{% include 'content-blocks/general_domain_requirements.md' %}
 
 [Read more about our domain name requirements](../requirements/).
 

--- a/pages/domains/domains_before.md
+++ b/pages/domains/domains_before.md
@@ -40,13 +40,7 @@ If you have your [Login.gov](https://login.gov/){.usa-link--external} account an
 
 We’ll ask you questions about your organization and the domain you want. Here’s what you’ll need to know to complete the form. There’s more information about each of these sections below.
 
-- Type of government organization you represent
-- Organization name and mailing address
-- Name, role, and contact information for your authorizing official
-- Purpose of the .gov domain
-- Current website for your organization (if you have one)
-- .Gov domain you want
-- Other employees from your organization
+{% include 'content-blocks/information_needed_for_domain_requests.md' %}
 
 ### Type of government organization you represent
 

--- a/pages/domains/domains_before.md
+++ b/pages/domains/domains_before.md
@@ -39,6 +39,7 @@ If you have your [Login.gov](https://login.gov/){.usa-link--external} account an
 ## Information you’ll need to complete the domain request form
 
 We’ll ask you questions about your organization and the domain you want. Here’s what you’ll need to know to complete the form. There’s more information about each of these sections below.
+
 - Type of government organization you represent
 - Organization name and mailing address
 - Name, role, and contact information for your authorizing official

--- a/pages/domains/domains_choosing.md
+++ b/pages/domains/domains_choosing.md
@@ -18,11 +18,7 @@ Your domain name represents your organization and your services to the world onl
 
 While internet domain names must be unique, names of government organizations can be similar or even identical. Our domain naming rules aim to prevent confusion.
 
-.gov domains must:
-- Be available
-- Be unique
-- Relate to your organization’s name, location, and/or services
-- Be clear to the general public. Your domain name must not be easily confused with other organizations.
+{% include 'content-blocks/general_domain_requirements.md' %}
 
 
 ## Only federal agencies can request generic terms

--- a/pages/domains/domains_eligibility.md
+++ b/pages/domains/domains_eligibility.md
@@ -24,7 +24,7 @@ If you’re eligible to have a .gov domain we want you to get one. The types of 
 {% include 'content-blocks/org_types.md' %}
 
 ## How we determine eligibility
-After you request a .gov domain, we'll review the information you provided about your organization. We use the [U.S. Census Bureau’s criteria for classifying governments](https://www.census.gov/programs-surveys/gus/technical-documentation/methodology/population-of-interest1.html){.usa-link--external} to help determine eligibility. In some cases, we'll request more information (such as legislation, a charter, or bylaws) to verify eligibility.
+After you request a .gov domain, we'll review the information you provided about your organization. We use the [U.S. Census Bureau’s criteria for classifying governments](https://www.census.gov/programs-surveys/gus/technical-documentation/methodology/population-of-interest1.html){.usa-link--external} to help determine eligibility. In some cases, we'll ask for more information (such as legislation, a charter, or bylaws) to verify eligibility.
 
 
 ## You must have approval from an authorizing official within your organization

--- a/pages/domains/domains_moving.md
+++ b/pages/domains/domains_moving.md
@@ -43,12 +43,7 @@ Identify who you’ll work with from your IT team (e.g., folks responsible for D
 
 We’ll try to give you your preferred domain. We’ll make sure your request meets our requirements. We’ll work with you to find the best domain for your organization.
 
-Your domain name must:
-
-- Be available ([Check availability](#))
-- Be unique
-- Relate to your organization's name, location, and/or services
-- Be clear to the general public. Your domain name must not be easily confused with other organizations.
+{% include 'content-blocks/general_domain_requirements.md' %}
 
 [Read more about our domain name requirements](../requirements/).
 

--- a/pages/help/help_account-management.md
+++ b/pages/help/help_account-management.md
@@ -42,17 +42,17 @@ If you already have a Login.gov account, you can use that account to sign into t
 
 ### If you already have a .gov account
 
-If you already have a .gov account you’ll need to have a Login.gov account to request or manage your .gov domains.
+If you already have a .gov account you’ll need to have a Login.gov account to request or manage your .gov domain.
 
 ## Access your .gov domain account
 
-If you already have a .gov account you’ll need to have a Login.gov account to request or manage your .gov domains. Follow these steps to [create your Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}.
+If you already have a .gov account you’ll need to have a Login.gov account to request or manage your .gov domain. Follow these steps to [create your Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}.
 
 ## Update your contact information (email, phone)
 You can change the contact information associated with a .gov domain you manage.
 
-1. If you don’t already have a Login.gov account, you’ll need to create one to manage existing .gov domains. <a href="https://login.gov/help/get-started/create-your-account/" class="usa-link usa-link--external">Create a Login.gov account</a>.
-2. Sign in with your Login.gov account to <a href="#">manage your domain</a>.  
+1. If you don’t already have a Login.gov account, you’ll need to create one to manage your .gov domain. [Create a Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}.
+2. Sign in with your Login.gov account to [manage your domain](#). 
 3. Click the “Manage” link for your .gov domain.
 4. Click “Your contact information” on the left-side navigation.
 5. Update your contact information.

--- a/pages/help/help_account-management.md
+++ b/pages/help/help_account-management.md
@@ -52,7 +52,7 @@ If you already have a .gov account you’ll need to have a Login.gov account to 
 You can change the contact information associated with a .gov domain you manage.
 
 1. If you don’t already have a Login.gov account, you’ll need to create one to manage your .gov domain. [Create a Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}.
-2. Sign in with your Login.gov account to [manage your domain](#). 
+2. [Sign in with your Login.gov account](#).
 3. Click the “Manage” link for your .gov domain.
 4. Click “Your contact information” on the left-side navigation.
 5. Update your contact information.

--- a/pages/help/help_domain-management.md
+++ b/pages/help/help_domain-management.md
@@ -27,7 +27,7 @@ You will receive an email notification about your changes.
 
 Follow these steps to add a security email for your .gov domain.
 
-1. If you don’t already have a Login.gov account, you’ll need to create one to manage existing .gov domains. <a href="https://login.gov/help/get-started/create-your-account/" class="usa-link usa-link--external">Create a Login.gov account</a>. 
+1. If you don’t already have a Login.gov account, you’ll need to create one to manage your .gov domain. [Create a Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}.
 2. Sign in with your Login.gov account to <a href="#">manage your domain</a>.  
 3. Click the “Manage” link for your .gov domain.
 4. Click “Security email” on the left-side navigation.
@@ -45,7 +45,7 @@ You will receive an email notification about your changes.
 
 You can change the contact information associated with a .gov domain you manage.
 
-1. If you don’t already have a Login.gov account, you’ll need to create one to manage existing .gov domains. <a href="https://login.gov/help/get-started/create-your-account/" class="usa-link usa-link--external">Create a Login.gov account</a>.
+1. If you don’t already have a Login.gov account, you’ll need to create one to manage your .gov domain. [Create a Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}.
 2. Sign in with your Login.gov account to <a href="#">manage your domain</a>.  
 3. Click the “Manage” link for your .gov domain.
 4. Click “Your contact information” on the left-side navigation.

--- a/pages/help/help_domain-management.md
+++ b/pages/help/help_domain-management.md
@@ -34,7 +34,7 @@ Follow these steps to add a security email for your .gov domain.
 5. Add or update the security email.
 6. Click “Submit.”
 
-You will receive an email notification about this change. Adding a security email is a security best practice. Learn about other best practices to manage your domain securely.  
+You will receive an email notification about this change. Adding a security email is a security best practice. Learn about other [best practices to manage your domain securely]({{'../../domains/security/'}}).
 
 ## Add people to help manage your .gov domain
 [Content to add](#)

--- a/pages/help/help_domain-management.md
+++ b/pages/help/help_domain-management.md
@@ -28,7 +28,7 @@ You will receive an email notification about your changes.
 Follow these steps to add a security email for your .gov domain.
 
 1. If you don’t already have a Login.gov account, you’ll need to create one to manage your .gov domain. [Create a Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}.
-2. Sign in with your Login.gov account to <a href="#">manage your domain</a>.  
+2. [Sign in with your Login.gov account](#). 
 3. Click the “Manage” link for your .gov domain.
 4. Click “Security email” on the left-side navigation.
 5. Add or update the security email.
@@ -46,7 +46,7 @@ You will receive an email notification about your changes.
 You can change the contact information associated with a .gov domain you manage.
 
 1. If you don’t already have a Login.gov account, you’ll need to create one to manage your .gov domain. [Create a Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}.
-2. Sign in with your Login.gov account to <a href="#">manage your domain</a>.  
+2. [Sign in with your Login.gov account](#).  
 3. Click the “Manage” link for your .gov domain.
 4. Click “Your contact information” on the left-side navigation.
 5. Update your contact information.

--- a/pages/help/help_domain-requests.md
+++ b/pages/help/help_domain-requests.md
@@ -70,7 +70,7 @@ See [examples of authorizing officials for different types of organizations]({{'
 
 We’ll ask you questions about your organization and the domain you want. Here’s what you’ll need to know to complete the form. 
 
-{% include 'content-blocks/information_needed_for_domain_requests.md' %}
+{% include 'content-blocks/information_needed_for_domain_request.md' %}
 
 Read more about [what you’ll need to complete the request form]({{'../../domains/before/#information-you’ll-need-to-complete-the-domain-request-form'}}).
 

--- a/pages/help/help_domain-requests.md
+++ b/pages/help/help_domain-requests.md
@@ -94,7 +94,7 @@ You will receive an email notification about your changes.
 
 ## Check the status of your domain request
 
-You can check the status of your domain request at any time. Sign in with your Login.gov account to <a href="#">manage your domain</a>. The status of your domain request will be on this page under “Active domain requests.”
+You can check the status of your domain request at any time. <a href="#">Sign in with your Login.gov account</a>. This will take you to the domain management page. The status of your domain request will be on this page under “Active domain requests.”
     
 The statuses for domain requests are:
 - **Started**: Your domain request has been started.

--- a/pages/help/help_domain-requests.md
+++ b/pages/help/help_domain-requests.md
@@ -82,7 +82,7 @@ You can make changes to your domain request after you submit it. To change your 
 
 Follow these steps to make changes. 
 
-1. Sign in with your Login.gov account to [manage your domain](#).
+1. [Sign in with your Login.gov account](#).
 2. Click the “Manage” link for the domain you want to change. This takes you to the domain overview page.
 3. Click the “Withdraw request” button to withdraw your request.
 4. Confirm that you want to withdraw your request. This takes you back to the domain management page.
@@ -108,7 +108,7 @@ You can withdraw your domain request after you submit it. Withdrawing your reque
 
 Follow these steps to withdraw your domain request.
 
-1. Sign in with your Login.gov account to [manage your domain](#).
+1. [Sign in with your Login.gov account](#).
 2. Click the “Manage” link for the domain you want to change. This takes you to the domain overview page.
 3. Click the “Withdraw request” button to withdraw your request.
 4. Confirm that you want to withdraw your request. This takes you back to the domain management page. The status of your request will say “Withdrawn.”

--- a/pages/help/help_domain-requests.md
+++ b/pages/help/help_domain-requests.md
@@ -82,9 +82,9 @@ You can make changes to your domain request after you submit it. To change your 
 
 Follow these steps to make changes. 
 
-1. Sign in with your Login.gov account to <a href="#">manage your domain</a>.
+1. Sign in with your Login.gov account to [manage your domain](#).
 2. Click the “Manage” link for the domain you want to change. This takes you to the domain overview page.
-3. Click the “Withdraw request” button to withdraw your request.</li>
+3. Click the “Withdraw request” button to withdraw your request.
 4. Confirm that you want to withdraw your request. This takes you back to the domain management page.
 5. Click the “Manage” link for the domain you want to change. This takes you to the domain overview page.
 6. Go to the section of the request you want to change. Make your changes. 
@@ -108,7 +108,7 @@ You can withdraw your domain request after you submit it. Withdrawing your reque
 
 Follow these steps to withdraw your domain request.
 
-1. Sign in with your Login.gov account to <a href="#">manage your domain</a>.
+1. Sign in with your Login.gov account to [manage your domain](#).
 2. Click the “Manage” link for the domain you want to change. This takes you to the domain overview page.
 3. Click the “Withdraw request” button to withdraw your request.
 4. Confirm that you want to withdraw your request. This takes you back to the domain management page. The status of your request will say “Withdrawn.”

--- a/pages/help/help_domain-requests.md
+++ b/pages/help/help_domain-requests.md
@@ -85,15 +85,14 @@ Follow [these steps to create your Login.gov account](https://login.gov/help/get
 You can make changes to your domain request after you submit it. To change your request you have to withdraw it, make your changes, and submit it again. Changing your request might add to the wait time for the .gov to review it.
 
 Follow these steps to make changes. 
-<ol>
-<li>Sign in with your Login.gov account to <a href="#">manage your domain</a>.</li> 
-<li>Click the “Manage” link for the domain you want to change. This takes you to the domain overview page.</li>
-<li>Click the “Withdraw request” button to withdraw your request.</li>
-<li>Confirm that you want to withdraw your request. This takes you back to the domain management page.</li>
-<li>Click the “Manage” link for the domain you want to change. This takes you to the domain overview page.</li>
-<li>Go to the section of the request you want to change. Make your changes.</li> 
-<li>Click “Submit.”</li>
-</ol>
+
+1. Sign in with your Login.gov account to <a href="#">manage your domain</a>.
+2. Click the “Manage” link for the domain you want to change. This takes you to the domain overview page.
+3. Click the “Withdraw request” button to withdraw your request.</li>
+4. Confirm that you want to withdraw your request. This takes you back to the domain management page.
+5. Click the “Manage” link for the domain you want to change. This takes you to the domain overview page.
+6. Go to the section of the request you want to change. Make your changes. 
+7. Click “Submit.”
 
 You will receive an email notification about your changes. 
 
@@ -112,12 +111,11 @@ The statuses for domain requests are:
 You can withdraw your domain request after you submit it. Withdrawing your request means that the .gov team will not review your domain request application. No action on your request will be taken.
 
 Follow these steps to withdraw your domain request.
-<ol>
-<li>Sign in with your Login.gov account to <a href="#">manage your domain</a>.</li> 
-<li>Click the “Manage” link for the domain you want to change. This takes you to the domain overview page.</li>
-<li>Click the “Withdraw request” button to withdraw your request.</li>
-<li>Confirm that you want to withdraw your request. This takes you back to the domain management page. The status of your request will say “Withdrawn.”</li>
-</ol>
+
+1. Sign in with your Login.gov account to <a href="#">manage your domain</a>.
+2. Click the “Manage” link for the domain you want to change. This takes you to the domain overview page.
+3. Click the “Withdraw request” button to withdraw your request.
+4. Confirm that you want to withdraw your request. This takes you back to the domain management page. The status of your request will say “Withdrawn.”
   
 You will receive an email notification that you withdrew your request. 
 

--- a/pages/help/help_domain-requests.md
+++ b/pages/help/help_domain-requests.md
@@ -37,7 +37,7 @@ Government organizations at all levels are eligible for .gov domains. These incl
 
 {% include 'content-blocks/org_types.md' %}
 
-After you request a .gov domain, we'll review the information you provided about your organization. We use the [U.S. Census Bureau’s criteria for classifying governments](https://www.census.gov/programs-surveys/gus/technical-documentation/methodology/population-of-interest1.html){.usa-link--external} to help determine eligibility. In some cases, we'll request more information (such as legislation, a charter, or bylaws) to verify eligibility.
+After you request a .gov domain, we'll review the information you provided about your organization. We use the [U.S. Census Bureau’s criteria for classifying governments](https://www.census.gov/programs-surveys/gus/technical-documentation/methodology/population-of-interest1.html){.usa-link--external} to help determine eligibility. In some cases, we'll request more information (such as legislation, a charter, or bylaws) to verify eligibility. 
 
 ### Domain name: choose a .gov domain name that complies with our naming requirements
 
@@ -70,13 +70,7 @@ See [examples of authorizing officials for different types of organizations]({{'
 
 We’ll ask you questions about your organization and the domain you want. Here’s what you’ll need to know to complete the form. 
 
-- Type of government organization you represent
-- Organization name and mailing address
-- Name, role, and contact information for your authorizing official
-- Purpose of the .gov domain
-- Current website for your organization (if you have one)
-- .Gov domain you want
-- Other employees from your organization
+{% include 'content-blocks/information_needed_for_domain_requests.md' %}
 
 Read more about [what you’ll need to complete the request form]({{'../../domains/before/#information-you’ll-need-to-complete-the-domain-request-form'}}).
 

--- a/pages/help/help_domain-requests.md
+++ b/pages/help/help_domain-requests.md
@@ -47,11 +47,7 @@ Your domain name represents your organization and your services to the world onl
 
 While internet domain names must be unique, names of government organizations can be similar or even identical. Our domain naming rules aim to prevent confusion.
 
-.gov domains must:
-- Be available 
-- Be unique
-- Relate to your organization’s name, location, and/or services
-- Be clear to the general public. Your domain name must not be easily confused with other organizations.
+{% include 'content-blocks/general_domain_requirements.md' %}
 
 See [domain name requirements and domain examples for different types of organizations]({{'../../domains/choosing/'}}).
 

--- a/pages/help/help_domain-requests.md
+++ b/pages/help/help_domain-requests.md
@@ -94,7 +94,7 @@ You will receive an email notification about your changes.
 
 ## Check the status of your domain request
 
-You can check the status of your domain request at any time. <a href="#">Sign in with your Login.gov account</a>. This will take you to the domain management page. The status of your domain request will be on this page under “Active domain requests.”
+You can check the status of your domain request at any time. [Sign in with your Login.gov account](#). This will take you to the domain management page. The status of your domain request will be on this page under “Active domain requests.”
     
 The statuses for domain requests are:
 - **Started**: Your domain request has been started.


### PR DESCRIPTION
## Changes proposed in this pull request:
- Added content blocks for general domain requirements and the list of info needed to make a domain request
- Removed HTML list code (ol/li)
- Updated initial instructions for signing in to make changes. I'm mostly referring to a singular domain in these instructions because that seems to fit the context better. As most users will only have one domain perhaps we should change the "Manage your domains" button to be singular. I don't feel strongly about that though.
