### PR TITLE
Update external link icons in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -42,7 +42,7 @@
       >
         <p class="usa-identifier__identity-domain">get.gov</p>
         <p class="usa-identifier__identity-disclaimer">
-          An official website of the <a href="https://www.cisa.gov" class="usa-link usa-link--external">Cybersecurity and Infrastructure Security Agency</a>
+          An official website of the <a href="https://www.cisa.gov" class="usa-link">Cybersecurity and Infrastructure Security Agency</a>
         </p>
       </section>
     </div>
@@ -73,7 +73,7 @@
           >
         </li>
         <li class="usa-identifier__required-links-item">
-          <a href="https://www.dhs.gov/accessibility" class="usa-identifier__required-link usa-link"
+          <a href="https://www.dhs.gov/accessibility" class="usa-identifier__required-link usa-link usa-link--external"
             >Accessibility</a
           >
         </li>
@@ -88,7 +88,7 @@
           >
         </li>
         <li class="usa-identifier__required-links-item">
-          <a href="https://www.dhs.gov/freedom-information-act-foia" class="usa-identifier__required-link usa-link"
+          <a href="https://www.dhs.gov/freedom-information-act-foia" class="usa-identifier__required-link usa-link usa-link--external"
             >FOIA requests</a
           >
         </li>
@@ -103,6 +103,6 @@
       <div class="usa-identifier__usagov-description">
         Looking for U.S. government information and services?
       </div>
-      <a href="https://www.usa.gov/" class="usa-link">Visit USA.gov</a>
+      <a href="https://www.usa.gov/" class="usa-link usa-link--external"">Visit USA.gov</a>
     </div>
   </section>


### PR DESCRIPTION
All links outside of CISA should have the external link icon

## Changes proposed in this pull request:
- Add/remove external link icons in the footer
