### PR TITLE
Update blog styles

### DIFF
--- a/_includes/blog-preview.html
+++ b/_includes/blog-preview.html
@@ -7,7 +7,7 @@
         {{ post.data.title }}
       </a>
     </h3>
-    <time class="text-base" 
+    <time class="text-base-dark" 
           datetime="{{ post.date | date: '%Y-%m-%dT12:00:00+01:00' }}"
     >
       {{ post.date | date: '%m/%d/%y' }}

--- a/_includes/collection-item.html
+++ b/_includes/collection-item.html
@@ -31,7 +31,9 @@
        {% assign tagSlug = tag | downcase | slugify %}
        {% assign tagURL = '/blog/tag/' | append: tagSlug %}
        <a class="text-no-underline" href="{{ tagURL | url }}">
-         <span class="usa-tag text-no-uppercase bg-primary">{{tag}}</span>
+         <span class="usa-tag text-no-uppercase bg-primary white-space--nowrap">
+           {{tag}}
+         </span>
        </a>
     {% endfor %}
     </div>

--- a/_includes/collection-item.html
+++ b/_includes/collection-item.html
@@ -1,5 +1,5 @@
 <li class="postpreview margin-top-4 padding-left-2 ">
-  <div class="postpreview_body">
+  <div class="postpreview__body">
   {% if post.data.image %}
     {% assign imagepath="./_img/" | append: post.data.image %}
     {% image_with_class imagepath "margin-bottom-1 maxw-8" post.data.image_alt_text %}
@@ -18,7 +18,7 @@
       </li>
       <li 
       class="postpreview__meta-item postpreview__date 
-            text-base text-uppercase font-sans-2xs"
+            text-base-dark text-uppercase font-sans-2xs"
        >
         <time datetime="{{ post.date | date: '%Y-%m-%dT12:00:00+01:00' }}">
           {{ post.date | date: '%B %d, %Y' }}

--- a/_includes/layouts/blog.html
+++ b/_includes/layouts/blog.html
@@ -63,12 +63,13 @@ title: Blog
           View posts by category
         </h3>
         <ul class="usa-list usa-list--unstyled">
-         {% for tagname in collections.blogTags reversed %}
+         {% assign tagNames = collections.blogTags | sort %}
+         {% for tagName in tagNames %}
          <li>
-           {% assign tagSlug = tagname | downcase | slugify %}
+           {% assign tagSlug = tagName | downcase | slugify %}
            {% assign tagURL = '/blog/tag/' | append: tagSlug %}
            <a class="usa-link" href="{{ tagURL | url }}" > 
-             {{ tagname }} ({{ collections[tagname].length }})
+             {{ tagName }} ({{ collections[tagName].length }})
            </a> 
          </li>
          {% endfor %}

--- a/_includes/layouts/post.html
+++ b/_includes/layouts/post.html
@@ -15,7 +15,7 @@ This is used in blog/news posts. The index page can be found at blog/index.html
       </div>
       <div class="usa-layout-docs__main tablet:grid-col-8 margin-top-neg-05 usa-prose">
         <h1 class="post__title margin-top-neg-2">{{title}}</h1>
-        <div class="text-base margin-bottom-3 margin-top-105">
+        <div class="text-base-dark margin-bottom-3 margin-top-105">
           <div class="post__author">
             By <span class="text-semibold text-primary-darker">{{ author }}</span> 
           </div>

--- a/styles/_uswds-theme-custom-styles.scss
+++ b/styles/_uswds-theme-custom-styles.scss
@@ -13,6 +13,9 @@ UTILITIES
   background-color: color('primary-lightest');
 }
 
+.white-space--nowrap {
+  white-space: nowrap;
+}
 
 /*---------------------------------------------------------
 SITEWIDE
@@ -308,6 +311,10 @@ NEWS/BLOG
 
 .tags-list .usa-list--unstyled li {
   margin-bottom: units(1);
+}
+
+.usa-tag:only-of-type {
+  margin-right: units(0.5);
 }
 
 /*---------------------------------------------------------

--- a/styles/_uswds-theme-custom-styles.scss
+++ b/styles/_uswds-theme-custom-styles.scss
@@ -55,11 +55,6 @@ h2, .usa-prose h2 {
   line-height: line-height('heading', 3);
 }
 
-.usa-prose > h2:first-child,
-.usa-prose .postpreview_body h2 {
-  margin-top: 0;
-}
-
 .usa-section h2 {
   margin-top: 0;
   margin-bottom: units(3);
@@ -75,6 +70,7 @@ h3 {
   font-weight: font-weight('semibold');
 }
 
+// Overrides for the default usa-prose styles
 .usa-prose {
   h1 {
     margin-bottom: units(1);
@@ -83,6 +79,12 @@ h3 {
   h2 {
     max-width: measure(1);
     margin-top: units(4);
+    margin-bottom: 0;
+  }
+
+  > h2:first-child, 
+  .postpreview__body h2 {
+    margin-top: 0;
   }
 
   > h3 {


### PR DESCRIPTION
## ✍️ Changes proposed in this pull request:
This PR is a follow up addressing the issues noted in @michelle-rago's PR #65. The changes addressed here: 

1. Alphabetically sort the list of tags in the blog sidebar
2. Style tags to not break on words
3. Darken the date text on blog post previews
4. Fix the space after H2s in blog posts to match other content 

The descriptions are being removed in PR #68 

👓 [Preview](https://federalist-8a77ab29f-16f6-4f12-961c-96cf064cf070.sites.pages.cloud.gov/preview/cisagov/getgov-home/ik/blog-updates/blog/)