### PR TITLE
Update beta banner

### DIFF
--- a/_includes/beta-banner.html
+++ b/_includes/beta-banner.html
@@ -2,7 +2,7 @@
     <div class="usa-alert usa-alert--warning usa-alert--no-icon">
       <div class="usa-alert__body">
         <p class="usa-alert__text">
-        <strong>BETA SITE:</strong> This site is for testing purposes only. Please <strong>do not </strong> rely on the information on this site. For information on the current process for requesting a .gov domain please visit the main site, <a href="https://get.gov" class="usa-link">www.get.gov</a>
+        <strong>BETA SITE:</strong> This site is for testing purposes only. Please <strong>do not </strong> rely on the information on this site. For information on the current process for requesting a .gov domain please visit <a href="https://get.gov" class="usa-link">get.gov</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## ✍️  Changes proposed in this pull request

This PR proposes an update to the beta banner language to more explicitly note that the information on the beta site shouldn't be used by visitors. Also adds a link to the existing site. 

Happy to incorporate any changes or suggestion – I  wanted to get the conversation started. 

Addresses [#601](https://github.com/cisagov/getgov/issues/601)

👓  [Preview](https://federalist-877ab29f-16f6-4f12-961c-96cf064cf070.sites.pages.cloud.gov/preview/cisagov/getgov-home/ik/update-beta-banner/)