### PR TITLE
Add robots.txt and meta tags

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -16,6 +16,9 @@ module.exports = function (config) {
   // Copy the `admin` folders to the output
   config.addPassthroughCopy('admin');
 
+  // Copy the `robots.txt` file to the output
+  config.addPassthroughCopy('robots.txt');
+  
   // Copy USWDS init JS so we can load it in HEAD to prevent banner flashing
   config.addPassthroughCopy({'./node_modules/@uswds/uswds/dist/js/uswds-init.js': 'assets/js/uswds-init.js'});
 

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -30,6 +30,16 @@ to modify some of the meta-data for the site, this is the place to do it.
   <link rel="canonical" href="{{ page.url }}" />
   <meta property="og:url" content="{{ page.url }}" />
   <script async="" src="{{ assetPaths['uswds.js'] }} "></script>
+
+  <!-- Robots, setup for beta site. TODO: Remove for launch
+    ================================================== -->
+  <meta name="googlebot" content="noindex, nofollow" />
+  <meta name="googlebot-news" content="noindex, nofollow" />
+  <meta name="bingbot" content="noindex, nofollow" />
+  <meta name="msnbot" content="noindex, nofollow" />
+  <meta name="slurp" content="noindex, nofollow, noydir" />
+  <meta name="duckduckbot" content="noindex, nofollow" />
+
   <!-- Favicon 
     ================================================== -->
   <link rel="icon" type="image/png" sizes="32x32" href="{{'/img/favicons/favicon-32.png' | url }}">

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,6 @@
+User-agent: usasearch  
+Crawl-delay: 2
+
+User-agent: *
+Crawl-delay: 10
+Disallow: /

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,6 @@
 User-agent: usasearch  
 Crawl-delay: 2
+Disallow:
 
 User-agent: *
 Crawl-delay: 10


### PR DESCRIPTION
## ✍️ Changes proposed in this pull request:
This PR adds a robots.txt file along with meta tags in the header to block crawling by commercial search engines, while allowing future indexing by search.gov. Within the meta tags, I included tags for five large search engines. These meta tags should be removed in the future when the site gets ready for public launch. Similarly, robots.txt will need to be updated to allow commercial search engines. 

Closes [#618](https://github.com/cisagov/getgov/issues/618)