### PR TITLE
updated 404 link 'more blog posts' on Home page

### DIFF
--- a/_includes/blog-preview.html
+++ b/_includes/blog-preview.html
@@ -15,4 +15,4 @@
   </li>
   {% endfor %}
 </ul>
-<a class="usa-link" href="/blog/">More blog posts</a>
+<a class="usa-link" href="{{ '/blog/' | url }}">More blog posts</a>


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fixes [#703](https://github.com/cisagov/getgov/issues/703) the 404 link 'more blog posts' on the Home page

## security considerations
No security considerations that I'm aware of. 
