### PR TITLE
Add "Moving to .gov" link to Homepage

### DIFF
--- a/_includes/highlights.html
+++ b/_includes/highlights.html
@@ -69,8 +69,8 @@ sites will only have two while others may have six to eight.
                 {% uswds_icon "list" %}
               </div>
               <div class="usa-icon-list__content">
-                <a href="{{ '/domains/requirements' | url }}" class="usa-link highlight__learn__link">
-                  Requirements for operating a .gov domain
+                <a href="{{ '/domains/moving' | url }}" class="usa-link highlight__learn__link">
+                  Moving to .gov from another domain
                 </a>
               </div>
             </li>


### PR DESCRIPTION
## Removed link for "Requirements for operating a .gov domain." And replaced that with a link for "Moving to .gov from another domain."

