### PR TITLE
Fix assetPaths build issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,4 +120,3 @@ web_modules/
 _site
 public
 node_modules
-_data/assetPaths.json

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ For more about the template and it's functionality see [here](https://github.com
 
 `npm run dev`
 
+### Ignore assetPaths
+We want to avoid commiting the `assetPaths.json` file, but need to keep it out of the project `.gitignore` in order to allow eleventy to rebuild when it is changed. One solution to resolve this you issue is to add `assetPaths.json` to the git exclude list:
+1. Open up `.git/info/exclude`
+2. Add `assetPaths.json` to that file
+
 ## Adding new content and front matter
 You can create new pages by creating a new markdown file (.md) and adding “front matter” to the top of the markdown file. The front matter section starts and ends with three hyphens (---). It consists of key-value pairs that define some meta-data and options for the page. 
 You should set the following front matter on all pages.

--- a/_data/assetPaths.json
+++ b/_data/assetPaths.json
@@ -1,9 +1,0 @@
-{
-  "admin.js": "/assets/js/admin-44W43542.js",
-  "admin.map": "/assets/js/admin-44W43542.js.map",
-  "app.js": "/assets/js/app-XWR645AF.js",
-  "app.map": "/assets/js/app-XWR645AF.js.map",
-  "uswds.js": "/assets/js/uswds-init.js",
-  "styles.css": "/assets/styles/styles-EGZPWJZ2.css",
-  "styles.map": "/assets/styles/styles-EGZPWJZ2.css.map"
-}


### PR DESCRIPTION
## ✍️  Changes proposed in this pull request:
This PR removes the `assetPaths.json` from the `.gitignore` which fixes the issue of 11ty not rebuilding when a styles file is saved. Additionally it removes the file from git. However, this will require future developers to ignore the file in their local project git exclude (or in their global git ignore). I've added documentation in the README's "Getting started" section to capture this information. 

Closes [705](https://github.com/cisagov/getgov/issues/705)

👓 [Preview](https://federalist-877ab29f-16f6-4f12-961c-96cf064cf070.sites.pages.cloud.gov/preview/cisagov/getgov-home/ik/asset-paths-fix/)
