### PR TITLE
Add blog post to point to latest get.gov update

### DIFF
--- a/posts/2023-10-13-registrar-transition-update.md
+++ b/posts/2023-10-13-registrar-transition-update.md
@@ -1,0 +1,12 @@
+---
+title: .Gov registrar transition update
+layout: layouts/post
+date: 2023-10-13
+author: Cameron Dixon
+excerpt: New domain requests are paused until January 2024 as we transition to new infrastructure.
+tags:
+  - posts
+  - Program updates
+---
+
+We’re building a new way to get and manage .gov domains. This is a beta site and is for testing purposes only. Go to [get.gov to read about improvements coming to the .gov registrar and what these changes mean for you](https://get.gov/updates/2023/10/13/transition-update/). 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add blog post on the beta to link to the latest get.gov update (following the model we started with the previous post)
