### PR TITLE
Update banner text on getgov-home homepage

### DIFF
--- a/_data/assetPaths.json
+++ b/_data/assetPaths.json
@@ -3,7 +3,6 @@
   "admin.map": "/assets/js/admin-77FHK54G.js.map",
   "app.js": "/assets/js/app-XWR645AF.js",
   "app.map": "/assets/js/app-XWR645AF.js.map",
-  "uswds.js": "/assets/js/uswds-init.js",
   "styles.css": "/assets/styles/styles-XT7WQ5Z5.css",
   "styles.map": "/assets/styles/styles-XT7WQ5Z5.css.map"
 }

--- a/_includes/beta-banner.html
+++ b/_includes/beta-banner.html
@@ -2,7 +2,7 @@
     <div class="usa-alert usa-alert--warning usa-alert--no-icon">
       <div class="usa-alert__body">
         <p class="usa-alert__text">
-        <strong>BETA SITE:</strong> We’re building a new way to get a .gov. Take a look around, but don’t rely on this site yet. This site is for testing purposes only. Don’t enter real data into any form on this site. To learn about requesting a .gov domain, visit <a href="https://get.gov" class="usa-link">get.gov</a>
+        <strong>BETA SITE:</strong> We built a new way to request and manage .gov domains — a new .gov registrar. Take a look around, but don’t rely on this site yet. This site is for testing purposes only. Don’t enter real data into any form on this site. Visit <a href="https://get.gov" class="usa-link">get.gov</a> for the latest updates on the new .gov registrar.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Changes proposed in this pull request:
Resolves [#1290](https://github.com/cisagov/manage.get.gov/issues/1290) on manage.get.gov. Changes can be previewed on [staging](https://federalist-877ab29f-16f6-4f12-961c-96cf064cf070.sites.pages.cloud.gov/preview/cisagov/getgov-home/es/1290-update-banner/). 

<img width="1424" alt="image" src="https://github.com/cisagov/getgov-home/assets/121973038/8b5a630e-af3a-44fb-8bb8-28a5ad2a5cfb">

## security considerations
[Note the any security considerations here, or make note of why there are none]
