### PR TITLE
Remove "request a free .gov domain" subheading

### DIFF
--- a/pages/domains/domains_index.md
+++ b/pages/domains/domains_index.md
@@ -10,9 +10,5 @@ eleventyNavigation:
   title: Domains
   order: 1
 ---
-## Request a free .gov domain 
-
-Ready to request your .gov domain? 
-
 Start a .gov domain request{.usa-button}
 


### PR DESCRIPTION
"Domains" landing page: Removed the "Request a free .gov domain" subheading and intro text. That subheading looked like the title of the page, which was misleading. The button, alone, should suffice.

(part of content review for [1282](https://github.com/cisagov/manage.get.gov/issues/1282))