### PR TITLE
Adding the contact section back to the help landing page

### DIFF
--- a/pages/help/help_contact.md
+++ b/pages/help/help_contact.md
@@ -1,0 +1,10 @@
+---
+title: Contact us
+permalink: /help/contact/
+layout: layouts/info-page
+excerpt: Contact the .gov team with questions or comments 
+tags: help
+eleventyNavigation:
+  key: help
+  order: 5 
+---

--- a/pages/help/help_contact.md
+++ b/pages/help/help_contact.md
@@ -1,6 +1,6 @@
 ---
 title: Contact us
-permalink: /contact/
+permalink: /contact/contact.md
 layout: layouts/info-page
 excerpt: Contact the .gov team with questions or comments 
 tags: help

--- a/pages/help/help_contact.md
+++ b/pages/help/help_contact.md
@@ -1,6 +1,6 @@
 ---
 title: Contact us
-permalink: /contact/contact/
+permalink: /contact/contact.md/
 layout: layouts/info-page
 excerpt: Contact the .gov team with questions or comments 
 tags: help

--- a/pages/help/help_contact.md
+++ b/pages/help/help_contact.md
@@ -1,10 +1,31 @@
 ---
 title: Contact us
-permalink: /contact/contact.md/
+permalink: /help/contact/
 layout: layouts/info-page
 excerpt: Contact the .gov team with questions or comments 
 tags: help
 eleventyNavigation:
   key: help
-  order: 5 
+  order: 4 
 ---
+
+**[Send a message to the .gov team](https://forms.office.com/g/Uq30UkMYRu)**. 
+
+We’ll respond within one business day if a response is needed.
+
+## Visit us on GitHub
+
+- [GitHub code repository for the get.gov website](https://github.com/cisagov/getgov-home){.usa-link--external}
+- [GitHub code repository for the .gov registrar](https://github.com/cisagov/manage.get.gov){.usa-link--external}
+
+## Report a system vulnerability
+
+We encourage you to report potential vulnerabilities in our systems. Read our [vulnerability disclosure policy](../vulnerability-disclosure-policy) to learn how to report a vulnerability.
+
+## Connect with your CISA regional representative
+
+CISA regional representatives can help you support the security and resilience of critical infrastructure. Our experts collaborate with communities at the regional, state, county, tribal, and local levels. [Find your CISA regional contact](https://www.cisa.gov/about/regions).
+
+## Join free cybersecurity group
+
+Join the free [Multi-State Information Sharing and Analysis Center](https://learn.cisecurity.org/ms-isac-registration){.usa-link--external} (MS-ISAC). CISA designated MS-ISAC as the [key resource for cyber threat prevention, protection, response, and recovery](https://www.cisa.gov/information-sharing-and-awareness) for all U.S. state, local, tribal, and territorial governments. MS-ISAC helps ensure the resiliency of government systems through coordination, cooperation, and communication.

--- a/pages/help/help_contact.md
+++ b/pages/help/help_contact.md
@@ -1,6 +1,6 @@
 ---
 title: Contact us
-permalink: /contact/contact.md
+permalink: /contact/contact/
 layout: layouts/info-page
 excerpt: Contact the .gov team with questions or comments 
 tags: help

--- a/pages/help/help_contact.md
+++ b/pages/help/help_contact.md
@@ -1,6 +1,6 @@
 ---
 title: Contact us
-permalink: /help/contact/
+permalink: /contact/
 layout: layouts/info-page
 excerpt: Contact the .gov team with questions or comments 
 tags: help


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adding the contact section back to the help landing page (after I deleted it by mistake!)
