### PR TITLE
Issue #1307 Removed extra ".gov" string from check availability text

### DIFF
--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -18,12 +18,16 @@ TODO: Domain search description
         fetch(searchEndpoint).then(function(reply) {
             return reply.json()
         }).then(function(response) {
+            var requested_domain_display_string = requested_domain
+                if (!requested_domain_display_string.endsWith('.gov')) {
+                    requested_domain_display_string += '.gov'
+                }
             if (response.available) {
                 render_result(`
                 <div class="usa-alert usa-alert--success usa-alert--slim" role="alert">
                     <div class="usa-alert__body">
                         <p class="usa-alert__text">
-                        <b>${requested_domain}.gov</b> is available!
+                        <b>${requested_domain_display_string}</b> is available!
                             <a class="usa-link" href="{{ '/domains/before/' | url }}">
                                 Read about next steps to take before requesting your .gov domain.
                             </a>
@@ -38,7 +42,7 @@ TODO: Domain search description
                 <div class="usa-alert usa-alert--error usa-alert--slim" role="alert">
                     <div class="usa-alert__body">
                         <p class="usa-alert__text">
-                            <b>${requested_domain}.gov</b> isn't available.
+                            <b>${requested_domain_display_string}</b> isn't available.
                             <a class="usa-link" href="{{ '/domains/choosing/' | url }}">
                                 Read more about choosing your .gov domain.
                             </a>


### PR DESCRIPTION
## Changes proposed in this pull request:
- Added a conditional that prevents appending an extra ".gov" string in the check availability message if the user's search string already ends in ".gov"

## security considerations
[Note the any security considerations here, or make note of why there are none]
