### PR TITLE
Issue #1318 - pressing ENTER on domain search clicks check availability button

### DIFF
--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -101,7 +101,10 @@ TODO: Domain search description
                     class="usa-button availability-button" 
                     type="button"
                     onclick="checkDomainAvailability()"
-                    onsubmit="return false">
+                    onsubmit="return false"
+                    aria-label="Check availability of Domain Name"
+                    title="Check Domain Availability"
+                    >
                         Check availability
                     </button>
             </form>

--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -56,6 +56,16 @@ TODO: Domain search description
     function render_result(content, append = true){
       document.getElementById('domain-available-message').innerHTML = (append == true) ? content : `<div></div>`;
     }
+
+    document.addEventListener("keypress", function(event) {
+        // If the user presses the "Enter" key on the keyboard
+        if (event.key === "Enter") {
+            // Cancel the default action
+            event.preventDefault();
+            // Click the "check availability" button
+            document.getElementById("check-domain-availability-button").click();
+        }
+    });
     
 </script>
 
@@ -87,6 +97,7 @@ TODO: Domain search description
                 >
                     <span class="usa-search__submit-text">.gov</span>
                     <button 
+                    id="check-domain-availability-button"
                     class="usa-button availability-button" 
                     type="button"
                     onclick="checkDomainAvailability()"

--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -94,6 +94,8 @@ TODO: Domain search description
                     type="search" 
                     name="query" 
                     autocomplete="off"
+                    aria-label="Check Domain Name input"
+                    title="Check Domain input"
                 >
                     <span class="usa-search__submit-text">.gov</span>
                     <button 


### PR DESCRIPTION
Pressing "enter" on domain name search clicks "check availability" button instead of page refresh.

## Changes proposed in this pull request:
- Override for key press on domain name search input.  If user presses "Enter", the "Check availability" button is clicked and the pae does not refresh

## security considerations
[Note the any security considerations here, or make note of why there are none]
