### PR TITLE
Update availability endpoint in 11ty to match registrar

### DIFF
--- a/_data/assetPaths.json
+++ b/_data/assetPaths.json
@@ -3,6 +3,7 @@
   "admin.map": "/assets/js/admin-77FHK54G.js.map",
   "app.js": "/assets/js/app-XWR645AF.js",
   "app.map": "/assets/js/app-XWR645AF.js.map",
+  "uswds.js": "/assets/js/uswds-init.js",
   "styles.css": "/assets/styles/styles-XT7WQ5Z5.css",
   "styles.map": "/assets/styles/styles-XT7WQ5Z5.css.map"
 }

--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -43,7 +43,6 @@ TODO: Domain search description
                     <div class="usa-alert__body">
                         <p class="usa-alert__text">
                             <b>${requested_domain_display_string}</b> isn't available.
-                            ${response.message} 
                             <a class="usa-link" href="{{ '/domains/choosing/' | url }}">
                                 Read more about choosing your .gov domain.
                             </a>

--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -5,10 +5,7 @@ TODO: Domain search description
 <script>
     function checkDomainAvailability() {
         // TODO: update baseUrl to stable when Cloudflare migrates their data 11/15
-        // const baseUrl = "https://getgov-staging.app.cloud.gov/api/v1/available/?domain="
-        // Using Dave's sandbox url right now bc that's where he's pushed the newest API fix
-        const baseUrl = "https://getgov-dk.app.cloud.gov/api/v1/available/?domain="
-
+        const baseUrl = "https://getgov-staging.app.cloud.gov/api/v1/available/?domain="
 
         var requested_domain = document.getElementById('domain-input').value
 
@@ -46,7 +43,10 @@ TODO: Domain search description
                     <div class="usa-alert__body">
                         <p class="usa-alert__text">
                             <b>${requested_domain_display_string}</b> isn't available.
-                            ${response.message}
+                            ${response.message} 
+                        <a class="usa-link" href="{{ '/domains/choosing/' | url }}">
+                            Read more about choosing your .gov domain.
+                        </a>
                         </p>
                     </div>
                 </div>

--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -16,8 +16,7 @@ TODO: Domain search description
 
         // var searchEndpoint = new URL(requested_domain, baseUrl);
         var searchEndpoint = new URL("", baseUrl + requested_domain);
-
-
+        
         fetch(searchEndpoint).then(function(reply) {
             return reply.json()
         }).then(function(response) {
@@ -30,7 +29,7 @@ TODO: Domain search description
                 <div class="usa-alert usa-alert--success usa-alert--slim" role="alert">
                     <div class="usa-alert__body">
                         <p class="usa-alert__text">
-                        <b>${requested_domain_display_string}</b> is available!
+                        <b>${requested_domain_display_string}</b> is available !
                             <a class="usa-link" href="{{ '/domains/before/' | url }}">
                                 Read about next steps to take before requesting your .gov domain.
                             </a>
@@ -46,9 +45,7 @@ TODO: Domain search description
                     <div class="usa-alert__body">
                         <p class="usa-alert__text">
                             <b>${requested_domain_display_string}</b> isn't available.
-                            <a class="usa-link" href="{{ '/domains/choosing/' | url }}">
-                                Read more about choosing your .gov domain.
-                            </a>
+                            ${response.message}
                         </p>
                     </div>
                 </div>

--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -44,9 +44,9 @@ TODO: Domain search description
                         <p class="usa-alert__text">
                             <b>${requested_domain_display_string}</b> isn't available.
                             ${response.message} 
-                        <a class="usa-link" href="{{ '/domains/choosing/' | url }}">
-                            Read more about choosing your .gov domain.
-                        </a>
+                            <a class="usa-link" href="{{ '/domains/choosing/' | url }}">
+                                Read more about choosing your .gov domain.
+                            </a>
                         </p>
                     </div>
                 </div>

--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -27,7 +27,7 @@ TODO: Domain search description
                 <div class="usa-alert usa-alert--success usa-alert--slim" role="alert">
                     <div class="usa-alert__body">
                         <p class="usa-alert__text">
-                        <b>${requested_domain_display_string}</b> is available !
+                        <b>${requested_domain_display_string}</b> is available!
                             <a class="usa-link" href="{{ '/domains/before/' | url }}">
                                 Read about next steps to take before requesting your .gov domain.
                             </a>

--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -5,7 +5,8 @@ TODO: Domain search description
 <script>
     function checkDomainAvailability() {
         // TODO: update baseUrl to stable when Cloudflare migrates their data 11/15
-        const baseUrl = "https://getgov-staging.app.cloud.gov/api/v1/available/"
+        const baseUrl = "https://getgov-dk.app.cloud.gov/api/v1/available/?domain="
+
 
         var requested_domain = document.getElementById('domain-input').value
 
@@ -13,7 +14,9 @@ TODO: Domain search description
             render_result(``)
         }
 
-        var searchEndpoint = new URL(requested_domain, baseUrl);
+        // var searchEndpoint = new URL(requested_domain, baseUrl);
+        var searchEndpoint = new URL("", baseUrl + requested_domain);
+
 
         fetch(searchEndpoint).then(function(reply) {
             return reply.json()

--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -5,6 +5,8 @@ TODO: Domain search description
 <script>
     function checkDomainAvailability() {
         // TODO: update baseUrl to stable when Cloudflare migrates their data 11/15
+        // const baseUrl = "https://getgov-staging.app.cloud.gov/api/v1/available/?domain="
+        // Using Dave's sandbox url right now bc that's where he's pushed the newest API fix
         const baseUrl = "https://getgov-dk.app.cloud.gov/api/v1/available/?domain="
 
 
@@ -14,7 +16,6 @@ TODO: Domain search description
             render_result(``)
         }
 
-        // var searchEndpoint = new URL(requested_domain, baseUrl);
         var searchEndpoint = new URL("", baseUrl + requested_domain);
         
         fetch(searchEndpoint).then(function(reply) {


### PR DESCRIPTION
## Changes proposed in this pull request:



References [this PR](https://github.com/cisagov/manage.get.gov/pull/1439) for updating the availability endpoint in the registrar + updated error messaging for if a user adds `.` in their to be domain. Please note in the above PR, the error message of `Enter the .gov domain you want without any periods.` will display when you click "Save and Continue" which is correct -- currently the error messages are not synced and we are aware of that.

![image](https://github.com/cisagov/getgov-home/assets/13954664/dcd443a1-2e04-4f4b-999f-e937039c87f4)

This work will be done in a diff PR:
This PR is for updating the availability endpoint on the beta site + some error messaging changes (see [this Slack discussion](https://cisa-corp.slack.com/archives/C05BDEA3C11/p1701824406852919) for adding in the error messaging).

## security considerations
[Note the any security considerations here, or make note of why there are none]
