### PR TITLE
Issue 124: Fix sitemap to output absolute URLs

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -71,7 +71,8 @@ module.exports = function (config) {
   });
 
   // Sitemap will not load the overwritten absoluteUrl filter,
-  // so we'll define a fresh custom filter.
+  // so we'll define a fresh custom filter that'll use an env
+  // variable to build the full url.
   config.addFilter("customAbsoluteUrl", function(url) {
     return process.env.FQDN ? process.env.FQDN + url : url;
   });

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -9,6 +9,7 @@ const yaml = require("js-yaml");
 const svgSprite = require("eleventy-plugin-svg-sprite");
 const { imageShortcode, imageWithClassShortcode } = require('./config');
 
+// This package allows us to set a .env file in our local environments
 const dotenv = require('dotenv');
 dotenv.config();
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -72,10 +72,10 @@ module.exports = function (config) {
   });
 
   // Sitemap will not load the overwritten absoluteUrl filter,
-  // so we'll define a fresh custom filter that'll use the default
-  // BASEURL env variable to build the full url.
+  // so we'll define a fresh custom filter that'll use the SITE_URL
+  // env variable to build the full url.
   config.addFilter("customAbsoluteUrl", function(url) {
-    return process.env.BASEURL ? process.env.BASEURL + url : url;
+    return process.env.SITE_URL ? process.env.SITE_URL + url : url;
   });
 
   // Get the first `n` elements of a collection.

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -71,10 +71,10 @@ module.exports = function (config) {
   });
 
   // Sitemap will not load the overwritten absoluteUrl filter,
-  // so we'll define a fresh custom filter that'll use an env
-  // variable to build the full url.
+  // so we'll define a fresh custom filter that'll use the default
+  // BASEURL env variable to build the full url.
   config.addFilter("customAbsoluteUrl", function(url) {
-    return process.env.FQDN ? process.env.FQDN + url : url;
+    return process.env.BASEURL ? process.env.BASEURL + url : url;
   });
 
   // Get the first `n` elements of a collection.

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -9,6 +9,9 @@ const yaml = require("js-yaml");
 const svgSprite = require("eleventy-plugin-svg-sprite");
 const { imageShortcode, imageWithClassShortcode } = require('./config');
 
+const dotenv = require('dotenv');
+dotenv.config();
+
 module.exports = function (config) {
   // Set pathPrefix for site
   let pathPrefix = '/';
@@ -65,6 +68,12 @@ module.exports = function (config) {
   // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-date-string
   config.addFilter('htmlDateString', (dateObj) => {
     return DateTime.fromJSDate(dateObj, { zone: 'utc' }).toFormat('yyyy-LL-dd');
+  });
+
+  // Sitemap will not load the overwritten absoluteUrl filter,
+  // so we'll define a fresh custom filter.
+  config.addFilter("customAbsoluteUrl", function(url) {
+    return process.env.FQDN ? process.env.FQDN + url : url;
   });
 
   // Get the first `n` elements of a collection.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ CSS and SASS can be added or imported into the `styles/styles.scss`. You can als
 
 Javascript can be added to the admin UI or site UI by adding or importing code into the `js/admin.js` or `js/app.js` files respectively. This template uses [esbuild](https://esbuild.github.io/) to bundle your javascript and fingerprint the files in the site build.
 
+### Managing environment variables
+
+Environemnt variables are set and managed on [pages.cloud.gov](https://pages.cloud.gov/)
+
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for additional information.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Javascript can be added to the admin UI or site UI by adding or importing code i
 
 ### Managing environment variables
 
-Environemnt variables are set and managed on [pages.cloud.gov](https://pages.cloud.gov/)
+Environment variables are set and managed on [pages.cloud.gov](https://pages.cloud.gov/)
 
 ## Contributing
 

--- a/_data/assetPaths.json
+++ b/_data/assetPaths.json
@@ -3,6 +3,7 @@
   "admin.map": "/assets/js/admin-77FHK54G.js.map",
   "app.js": "/assets/js/app-XWR645AF.js",
   "app.map": "/assets/js/app-XWR645AF.js.map",
+  "uswds.js": "/assets/js/uswds-init.js",
   "styles.css": "/assets/styles/styles-XT7WQ5Z5.css",
   "styles.map": "/assets/styles/styles-XT7WQ5Z5.css.map"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@11ty/eleventy-plugin-rss": "^1.1.2",
         "autoprefixer": "^10.4.2",
         "chokidar-cli": "^3.0.0",
+        "dotenv": "^16.3.1",
         "eleventy-plugin-svg-sprite": "^1.3.1",
         "esbuild": "^0.14.25",
         "esbuild-sass-plugin": "^2.2.4",
@@ -2674,6 +2675,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/duplexer": {
@@ -12508,6 +12521,12 @@
         "domelementtype": "^2.2.0",
         "domhandler": "^4.2.0"
       }
+    },
+    "dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "dev": true
     },
     "duplexer": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@11ty/eleventy-plugin-rss": "^1.1.2",
     "autoprefixer": "^10.4.2",
     "chokidar-cli": "^3.0.0",
+    "dotenv": "^16.3.1",
     "eleventy-plugin-svg-sprite": "^1.3.1",
     "esbuild": "^0.14.25",
     "esbuild-sass-plugin": "^2.2.4",
@@ -47,8 +48,8 @@
   },
   "dependencies": {
     "@uswds/uswds": "3.1.0",
-    "markdown-it-attrs": "^4.1.6",
     "gulp": "^4.0.2",
+    "markdown-it-attrs": "^4.1.6",
     "pa11y-ci": "^3.0.1",
     "start-server-and-test": "^2.0.0"
   }

--- a/sitemap.xml.njk
+++ b/sitemap.xml.njk
@@ -5,9 +5,8 @@ eleventyExcludeFromCollections: true
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 {%- for page in collections.all %}
-  {% set absoluteUrl %}{{ page.url | url | absoluteUrl }}{% endset %}
   <url>
-    <loc>{{ absoluteUrl }}</loc>
+    <loc>{{ page.url | url | customAbsoluteUrl }}</loc>
     <lastmod>{{ page.date | htmlDateString }}</lastmod>
   </url>
 {%- endfor %}


### PR DESCRIPTION
Solves #124 

## Changes proposed in this pull request:
- Store site url in .env (locally)
- Pull site url in .eleventy.js and use it in a custom filter that prepends it to urls
- Use the custom filter in sitemap.xml.njk

## security considerations

Can we store the site url in an environment variable on production?
