### PR TITLE
Availability Endpoint has more explanatory err messaging for not available

### DIFF
--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -43,6 +43,7 @@ TODO: Domain search description
                     <div class="usa-alert__body">
                         <p class="usa-alert__text">
                             <b>${requested_domain_display_string}</b> isn't available.
+                            ${response.message} 
                             <a class="usa-link" href="{{ '/domains/choosing/' | url }}">
                                 Read more about choosing your .gov domain.
                             </a>


### PR DESCRIPTION
## Changes proposed in this pull request:

![image](https://github.com/cisagov/getgov-home/assets/13954664/5c7e65a5-9ae5-4843-bcc6-f3c254a5e6ad)

This PR is for updating the error messaging for domains that are not available (see [this Slack discussion](https://cisa-corp.slack.com/archives/C05BDEA3C11/p1701824406852919) for adding in the error messaging).

## security considerations
[Note the any security considerations here, or make note of why there are none]
