### PR TITLE
Issue #125 - updated error handling on check availability to use codes

### DIFF
--- a/_includes/domain-search.html
+++ b/_includes/domain-search.html
@@ -36,6 +36,18 @@ TODO: Domain search description
                 </div>
                 `
                 )
+            }
+            else if (response.code === 'error') {
+                render_result(`
+                <div class="usa-alert usa-alert--error usa-alert--slim" role="alert">
+                    <div class="usa-alert__body">
+                        <p class="usa-alert__text">
+                            ${response.message} 
+                        </p>
+                    </div>
+                </div>
+                `
+                )
             } 
             else {
                 render_result(`
@@ -44,9 +56,6 @@ TODO: Domain search description
                         <p class="usa-alert__text">
                             <b>${requested_domain_display_string}</b> isn't available.
                             ${response.message} 
-                            <a class="usa-link" href="{{ '/domains/choosing/' | url }}">
-                                Read more about choosing your .gov domain.
-                            </a>
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
Resolves: #125 

## Changes proposed in this pull request:
- Update check availability messaging to handle error code and display accordingly.  This allows for registry errors to display differently than available/not available messages
-

This PR cannot be merged until[ PR on manage.get.gov](https://github.com/cisagov/manage.get.gov/pull/1508) is pushed to staging.

This change is not easily staged to allow for RegistryErrors to be reproduced.  So, this PRwill need to be evaluated based on the screenshots below.  The screenshots below depict all of the variations of the success and error messages in the check availability box in beta.get.gov

## screenshots

Registry connection error screenshot:
![system-connection-error](https://github.com/cisagov/getgov-home/assets/111779554/7f1757ed-f176-4c6a-a25d-c26e1facc8b6)

Domain is available success message screenshot:
![success-message](https://github.com/cisagov/getgov-home/assets/111779554/12316333-cbc9-490d-a5c7-e7066200c8db)

Domain is unavailable error screenshot:
![unavailable-error](https://github.com/cisagov/getgov-home/assets/111779554/003ca447-3ca4-4c16-b25d-8b32cf8737ba)

Domain is invalid error screenshot:
![invalid-error](https://github.com/cisagov/getgov-home/assets/111779554/44195cbf-8bbd-4cae-86e2-e4a369ff1dda)


