### PR TITLE
Help_Domain Requests: Update content

### DIFF
--- a/pages/help/help_domain-requests.md
+++ b/pages/help/help_domain-requests.md
@@ -41,7 +41,7 @@ Follow these steps to make changes.
 1. Sign in to the [.gov registrar](https://manage.get.gov){target="_blank"} using your Login.gov account.
 2. Click the “Manage” link for the domain request you want to withdraw.
 3. Click the “Withdraw request” button.
-4. Confirm that you want to withdraw your request. This will take you back to the domain management page.
+4. Confirm that you want to withdraw your request. This will take you back to the domain dashboard.
 5. Click the “Edit” link next to your withdrawn request.
 6. Go to the section of the request you want to change. 
 7. Make your changes and submit the request.
@@ -50,7 +50,7 @@ You will receive an email notification that confirms your request has been submi
 
 ## Check the status of your domain request
 
-You can check the status of your domain request at any time. Sign in to the [.gov registrar](https://manage.get.gov){target="_blank"} using your Login.gov account. The status of your domain request will be on this page under “Domain requests.” 
+You can check the status of your domain request at any time. Sign in to the [.gov registrar](https://manage.get.gov){target="_blank"} using your Login.gov account. The status of your request will be displayed within the “Domain requests” table. 
     
 The statuses for domain requests are:
 - **Started**: Your domain request has been started.

--- a/pages/help/help_domain-requests.md
+++ b/pages/help/help_domain-requests.md
@@ -26,11 +26,11 @@ You must be a government employee, or be working on behalf of the government, to
 
 Follow these steps to complete your request as quickly as possible.{.checklist}
 
-- **Eligibility**: [Make sure your organization is eligible to have a .gov domain](../../eligibility/).
-- **Domain name**: [Choose an available .gov domain that complies with our requirements](../../choosing/).
-- **Authorizing official**: [Find out who your authorizing official is](../../eligibility/#you-must-have-approval-from-an-authorizing-official-within-your-organization) and make sure they approve your request.
-- **Request form**: Gather [all the information you’ll need](../../before/#information-you’ll-need-to-complete-the-domain-request-form) to complete your domain request.
-- **Account**: [Create a Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}. You’ll need a Login.gov account to request a .gov domain. [Login.gov](https://login.gov/){.usa-link--external} provides a simple and secure process for signing into many government services with one account.
+- **Eligibility**: [Make sure your organization is eligible to have a .gov domain](../../domains/eligibility/).
+- **Domain name**: [Choose an available .gov domain that complies with our requirements](../../domains/choosing/).
+- **Authorizing official**: [Find out who your authorizing official is](../../domains/eligibility/#you-must-have-approval-from-an-authorizing-official-within-your-organization) and make sure they approve your request.
+- **Request form**: Gather [all the information you’ll need](../../domains/before/#information-you’ll-need-to-complete-the-domain-request-form) to complete your domain request.
+- **Account**: [Create a Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}. You’ll need that account to request a .gov domain. [Login.gov](https://login.gov/){.usa-link--external} provides a simple and secure process for signing into many government services with one account.
 
 ## Change a domain request you already submitted
 

--- a/pages/help/help_domain-requests.md
+++ b/pages/help/help_domain-requests.md
@@ -9,15 +9,16 @@ eleventyNavigation:
   order: 2 
 ---
 
-- [What to do before you request your .gov domain](#before-you-request-your-.gov-domain)
+- [Request your .gov domain](#request-your-.gov-domain)
+- [Before you request your .gov domain](#before-you-request-your-.gov-domain)
 - [Change a domain request you already submitted](#change-a-domain-request-you-already-submitted)
 - [Check the status of your domain request](#check-the-status-of-your-domain-request)
 - [Withdraw your domain request](#withdraw-your-domain-request)
 
 ## Request your .gov domain
-Ready to request your .gov domain? 
+If you’re ready to request your .gov domain, then get started. You don’t have to complete the process in one session. You can save what you enter and come back to it when you’re ready.
 
-Start your .gov domain request{.usa-button}
+Start a .gov domain request{.usa-button}
 
 ## Before you request your .gov domain
 
@@ -25,53 +26,11 @@ You must be a government employee, or be working on behalf of the government, to
 
 Follow these steps to complete your request as quickly as possible.{.checklist}
 
-- [Eligibility](#eligibility%3A-make-sure-your-organization-is-eligible-to-have-a-.gov-domain): Make sure your organization is eligible to have a .gov domain.
-- [Domain name](#domain-name%3A-choose-a-.gov-domain-name-that-complies-with-our-naming-requirements): Choose a .gov domain that complies with our naming requirements.
-- [Authorizing official](#authorizing-official%3A-find-out-who-your-authorizing-official-is-and-make-sure-they-approve-your-request): Find out who your authorizing official is and make sure they approve your request.
-- [Request form](#request-form%3A-gather-the-information-needed-to-complete-the-request-form): Gather the information needed to complete the request form.
-- [Account](#account%3A-create-a-login.gov-account): Create a Login.gov account.
-
-### Eligibility: make sure your organization is eligible to have a .gov domain
-
-Government organizations at all levels are eligible for .gov domains. These include:
-
-{% include 'content-blocks/org_types.md' %}
-
-After you request a .gov domain, we'll review the information you provided about your organization. We use the [U.S. Census Bureau’s criteria for classifying governments](https://www.census.gov/programs-surveys/gus/technical-documentation/methodology/population-of-interest1.html){.usa-link--external} to help determine eligibility. In some cases, we'll request more information (such as legislation, a charter, or bylaws) to verify eligibility. 
-
-### Domain name: choose a .gov domain name that complies with our naming requirements
-
-#### .Gov domain names must be available, unique, and clear
-
-Your domain name represents your organization and your services to the world online. Good domain names are memorable, easy to say out loud (like over the phone or in a presentation), and must follow the general naming requirements and specific rules for your type of organization.
-
-While internet domain names must be unique, names of government organizations can be similar or even identical. Our domain naming rules aim to prevent confusion.
-
-{% include 'content-blocks/general_domain_requirements.md' %}
-
-See [domain name requirements and domain examples for different types of organizations]({{'../../domains/choosing/'}}).
-
-### Authorizing official: find out who your authorizing official is and make sure they approve your request
-
-Your authorizing official is a person within your organization who can authorize your domain request. This person must be in a role of significant, executive responsibility within the organization. 
-
-When you request a .gov domain, we'll ask for information about your authorizing official (role, contact information). We typically don’t reach out to them, but if contact is necessary, our practice is to coordinate first with you, the requestor.
-
-See [examples of authorizing officials for different types of organizations]({{'../../domains/eligibility/#you-must-have-approval-from-an-authorizing-official-within-your-organization'}}).
-
-### Request form: gather the information needed to complete the request form
-
-We’ll ask you questions about your organization and the domain you want. Here’s what you’ll need to know to complete the form. 
-
-{% include 'content-blocks/information_needed_for_domain_request.md' %}
-
-Read more about [what you’ll need to complete the request form]({{'../../domains/before/#information-you’ll-need-to-complete-the-domain-request-form'}}).
-
-### Account: create a Login.gov account
-
-You need a [Login.gov](https://login.gov/){.usa-link--external} account to request a .gov domain. Login.gov provides a simple and secure process for signing into many government services with one account.
-
-Follow [these steps to create your Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}.
+- **Eligibility**: [Make sure your organization is eligible to have a .gov domain](../eligibility/).
+- **Domain name**: [Choose an available .gov domain that complies with our requirements](../choosing/).
+- **Authorizing official**: [Find out who your authorizing official is](../eligibility/#you-must-have-approval-from-an-authorizing-official-within-your-organization) and make sure they approve your request.
+- **Request form**: Gather [all the information you’ll need](../before/#information-you’ll-need-to-complete-the-domain-request-form) to complete your domain request.
+- **Account**: [Create a Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}. You’ll need a Login.gov account to request a .gov domain. [Login.gov](https://login.gov/){.usa-link--external} provides a simple and secure process for signing into many government services with one account.
 
 ## Change a domain request you already submitted
 

--- a/pages/help/help_domain-requests.md
+++ b/pages/help/help_domain-requests.md
@@ -26,50 +26,54 @@ You must be a government employee, or be working on behalf of the government, to
 
 Follow these steps to complete your request as quickly as possible.{.checklist}
 
-- **Eligibility**: [Make sure your organization is eligible to have a .gov domain](../eligibility/).
-- **Domain name**: [Choose an available .gov domain that complies with our requirements](../choosing/).
-- **Authorizing official**: [Find out who your authorizing official is](../eligibility/#you-must-have-approval-from-an-authorizing-official-within-your-organization) and make sure they approve your request.
-- **Request form**: Gather [all the information you’ll need](../before/#information-you’ll-need-to-complete-the-domain-request-form) to complete your domain request.
+- **Eligibility**: [Make sure your organization is eligible to have a .gov domain](../../eligibility/).
+- **Domain name**: [Choose an available .gov domain that complies with our requirements](../../choosing/).
+- **Authorizing official**: [Find out who your authorizing official is](../../eligibility/#you-must-have-approval-from-an-authorizing-official-within-your-organization) and make sure they approve your request.
+- **Request form**: Gather [all the information you’ll need](../../before/#information-you’ll-need-to-complete-the-domain-request-form) to complete your domain request.
 - **Account**: [Create a Login.gov account](https://login.gov/help/get-started/create-your-account/){.usa-link--external}. You’ll need a Login.gov account to request a .gov domain. [Login.gov](https://login.gov/){.usa-link--external} provides a simple and secure process for signing into many government services with one account.
 
 ## Change a domain request you already submitted
 
-You can make changes to your domain request after you submit it. To change your request you have to withdraw it, make your changes, and submit it again. Changing your request might add to the wait time for the .gov to review it.
+To make changes to your domain request, you have to withdraw it first. Changing your request may extend the time it takes for the .gov team to complete their review.
 
 Follow these steps to make changes. 
 
-1. [Sign in with your Login.gov account](#).
-2. Click the “Manage” link for the domain you want to change. This takes you to the domain overview page.
-3. Click the “Withdraw request” button to withdraw your request.
-4. Confirm that you want to withdraw your request. This takes you back to the domain management page.
-5. Click the “Manage” link for the domain you want to change. This takes you to the domain overview page.
-6. Go to the section of the request you want to change. Make your changes. 
-7. Save your changes.
+1. Sign in to the [.gov registrar](https://manage.get.gov){target="_blank"} using your Login.gov account.
+2. Click the “Manage” link for the domain request you want to withdraw.
+3. Click the “Withdraw request” button.
+4. Confirm that you want to withdraw your request. This will take you back to the domain management page.
+5. Click the “Edit” link next to your withdrawn request.
+6. Go to the section of the request you want to change. 
+7. Make your changes and submit the request.
 
-You will receive an email notification about your changes. 
+You will receive an email notification that confirms your request has been submitted. 
 
 ## Check the status of your domain request
 
-You can check the status of your domain request at any time. [Sign in with your Login.gov account](#). This will take you to the domain management page. The status of your domain request will be on this page under “Active domain requests.”
+You can check the status of your domain request at any time. Sign in to the [.gov registrar](https://manage.get.gov){target="_blank"} using your Login.gov account. The status of your domain request will be on this page under “Domain requests.” 
     
 The statuses for domain requests are:
 - **Started**: Your domain request has been started.
-- **Received**: Your domain request has been completed and submitted.
+- **Submitted**: Your domain request has been completed and submitted.
 - **In review**: Your domain request is being reviewed by the .gov team.
-- **Withdrawn**: Your domain request has been withdrawn and will not be reviewed by the .gov team.
+- **Action needed**: The .gov team has a question about your request or needs more information to move forward with their review. They will reach out to you with more details.
+- **Withdrawn**: Your domain request has been withdrawn and will not be reviewed by the .gov team. In this status, you have the option to edit and resubmit the request.
+- **Approved**: Your domain request has been approved. Before the domain can be used, you’ll need to add name servers.
+- **Rejected**: Your domain request has been rejected. In this status, you have the option to withdraw the request, which will allow you to edit and resubmit it.
+
 
 ## Withdraw your domain request
     
-You can withdraw your domain request after you submit it. Withdrawing your request means that the .gov team will not review your domain request application. No action on your request will be taken.
+You can withdraw your domain request after you submit it. Withdrawing your request means that the .gov team will not review your domain request. 
 
 Follow these steps to withdraw your domain request.
 
-1. [Sign in with your Login.gov account](#).
-2. Click the “Manage” link for the domain you want to change. This takes you to the domain overview page.
-3. Click the “Withdraw request” button to withdraw your request.
-4. Confirm that you want to withdraw your request. This takes you back to the domain management page. The status of your request will say “Withdrawn.”
+1. Sign in to the [.gov registrar](https://manage.get.gov){target="_blank"} using your Login.gov account.
+2. Click the “Manage” link for the domain request you want to withdraw.
+3. Click the “Withdraw request” button.
+4. Confirm that you want to withdraw your request. This will take you back to the domain dashboard. 
   
-You will receive an email notification that you withdrew your request. 
+You will receive an email notification that confirms your request has been withdrawn. 
 
 
 


### PR DESCRIPTION
Quite a few content updates on this page. While reviewing, reference the related [Google doc](https://docs.google.com/document/d/1U7MLSXvDJsAxfEzPdKXoy6-wBL9IKynJ9JLDHTrEjxY/edit) and start comment threads, as needed.

Two impactful revisions:

- The biggest change was within the "**Before you request your .gov domain**" section. The checklist in that section used to anchor link down to content on the same page. That anchored content has been removed and, instead, the checklist links to corresponding pages on the beta site. 
- Some of our **request statuses** were missing from this page. I added those and wrote  descriptions, but those may need to be modified. So pay special attention to that section. 
