### PR TITLE
Change .gov to .Gov for election offices link

### DIFF
--- a/_includes/learn-more.html
+++ b/_includes/learn-more.html
@@ -54,7 +54,7 @@
               </div>
               <div class="usa-icon-list__content">
                 <a href="{{ '/domains/election-offices' | url }}" class="usa-link highlight__learn__link">
-                  .gov domains for election offices
+                  .Gov domains for election offices
                 </a>
               </div>
             </li>


### PR DESCRIPTION
Minor update. Align with [Google doc](https://docs.google.com/document/d/1iVr2rv0fKUnKrxStT1cs_3jy-2Vzyzy-xRzfE0mumgw/edit).