### PR TITLE
Change 30 days to 10 in our docs

### DIFF
--- a/pages/domains/domains_before.md
+++ b/pages/domains/domains_before.md
@@ -95,7 +95,7 @@ To help us determine your organization’s eligibility for a .gov domain, it’s
 
 ## What happens after you request your .gov domain
 
-We’ll review your request. This review period can take 30 business days. Due to the volume of requests, the wait time is longer than usual. We appreciate your patience. 
+We’ll review your request. This review period usually takes around 10 business days.
 
 During our review we’ll verify that:
 - Your organization is eligible for a .gov domain

--- a/pages/domains/domains_moving.md
+++ b/pages/domains/domains_moving.md
@@ -39,7 +39,7 @@ Read more about each of these steps below.{.checklist}
 
 Getting a .gov domain is different from purchasing a .com or .org address. That's because we conduct a review on each domain request, and these take time. We don't operate on a first-come, first-served basis.
 
-If you have important deadlines to meet, plan ahead when moving to a .gov domain. We’ll need to review your domain request, and that can take 30 business days. Due to the volume of requests, the wait time for completing our review is longer than usual.
+If you have important deadlines to meet, plan ahead when moving to a .gov domain. We’ll need to review your domain request, and that can take 10 business days or more.
 
 
 ## Start the conversation with your technical and communications staff

--- a/pages/help/help_faq.md
+++ b/pages/help/help_faq.md
@@ -53,7 +53,7 @@ The “cityname” and “detroit” part of the examples above are subdomains. 
 To use a subdomain for a particular .gov domain, like mi.gov, you need to coordinate with the registrant for that .gov domain. View [data for all .gov domains](../../about/data/), including points of contact for domains.
 
 ## How much longer until I hear back about a domain request? {#domain-request-status}
-Our review process can take 30 business days. Due to the volume of requests, the wait time is longer than usual. It also may take longer depending on the details of your request. 
+Our review process usually takes about 10 business days, but it can take longer depending on the details of your request. 
 
 You can [check the status of the domain request at any time](../domain-requests/#check-the-status-of-your-domain-request). If you have a question, [contact us](../../contact/). 
 


### PR DESCRIPTION
In https://github.com/cisagov/manage.get.gov/issues/3877, @montecristo99 prepared some changes that to bring review time from 30 days to 10 (usually).

This closes the get.gov part of https://github.com/cisagov/manage.get.gov/issues/4078.