### PR TITLE
Add link to the .gov roadmap

### DIFF
--- a/pages/about/product_updates.md
+++ b/pages/about/product_updates.md
@@ -11,7 +11,7 @@ eleventyNavigation:
   title: Product updates
 ---  
 
-We occasionally share brief notes about new features. We also maintain a [roadmap](https://github.com/orgs/cisagov/projects/100/views/1){.usa-link--external} (GitHub).
+We occasionally share brief notes about new features. We also maintain a [roadmap](https://github.com/orgs/cisagov/projects/100/views/1){.usa-link--external} on GitHub.
 
 ## November 18, 2025
 


### PR DESCRIPTION
This PR adds a link to our roadmap and lightly amends the unfurl text.