### PR TITLE
Update domains_moving.md

### DIFF
--- a/pages/domains/domains_moving.md
+++ b/pages/domains/domains_moving.md
@@ -49,7 +49,7 @@ Identify who you’ll work with from your IT team (e.g., folks responsible for D
 
 ## Come up with .gov domain options that meet our naming requirements
 
-We’ll try to give you your preferred domain. If it's not available or doesn't meet our naming  requirements, we’ll work with you to find the best domain for your organization.
+We’ll try to give you your preferred domain. If it's not available or doesn't meet our naming requirements, we’ll work with you to find the best domain for your organization.
 
 [Read more about our domain name requirements](../choosing/).
 


### PR DESCRIPTION
A small change to remove naming-requirement language out of the "moving" document.

This removes our call to https://github.com/cisagov/get.gov/blob/main/_includes/content-blocks/general_domain_requirements.md, related to the #461 work.

See [Google Docs](https://docs.google.com/document/d/1EL6pBxmLGMj3_b726H2Ai4yY3N7ukufW1Vu3cdTwE8M/edit?usp=sharing).