### PR TITLE
Remove confusing optional language from city domain guidelines

### DIFF
--- a/_includes/content-blocks/org-types.html
+++ b/_includes/content-blocks/org-types.html
@@ -113,7 +113,7 @@ abbreviation</em></div></li>
   </h2>
   <div id="cities" class="usa-accordion__content usa-prose">
     <p>This organization type includes cities, towns, townships, villages, etc.</p>
-    <p>Most city domains must include the two-letter state abbreviation or clearly spell out the state name. Using phrases like “City of” or “Town of” is optional.</p>
+    <p>Most city domains must include the two-letter state abbreviation or clearly spell out the state name.</p>
     <p>Cities that meet one of the criteria below don’t have to refer to their state in their domain name.</p>
     <ul>
       <li>The city name is not shared by any other U.S. city, town, village, or county. We use the <a href="https://www.census.gov/geographies/reference-files/time-series/geo/gazetteer-files.html" class="usa-link usa-link--external" target="_blank" rel="noopener noreferrer">Census Bureau’s National Places Gazetteer Files</a> to determine if names are unique.</li>


### PR DESCRIPTION
We recently updated our naming guideline. The "[Naming requirements for all organization types](https://get.gov/domains/choosing/)" says that that a domain "may need additional identifiers (like “county”, “township”, or “tribe”), but the "city" type guidance said "Using phrases like “City of” or “Town of” is optional." 

This PR modified the city type guidance so there isn't a discrepancy.