### PR TITLE
Remove request buttons

### DIFF
--- a/_includes/content-blocks/what_we_offer.md
+++ b/_includes/content-blocks/what_we_offer.md
@@ -1,9 +1,7 @@
 ## We offer support for your .gov domain
 ### What we offer {.h4}
 
-{% image_with_class "_img/icons/dns.svg" "icon-inline" "" %}**Domain registration**: {% modal-trigger--inline %} or learn about the [information you'll need to complete your request](../../domains/before).
-
-{% modal-body %}
+{% image_with_class "_img/icons/dns.svg" "icon-inline" "" %}**Domain registration**: Start a domain request or learn about the [information you'll need to complete your request](../../domains/before).
 
 {% image_with_class "_img/icons/speech.svg" "icon-inline" "" %}**Domain name consultation**: If you need help coming up with your .gov domain name, [contact us](../../contact).
 

--- a/pages/domains/domains_before.md
+++ b/pages/domains/domains_before.md
@@ -53,6 +53,3 @@ Read more about [domain management.](../../help/domain-management/)
 ## Start your domain request
 
 Ready to request a .gov domain? Get started! You don’t have to complete the process in one session. You can save your progress and come back to it when you’re ready. 
-
-{% modal-trigger--button %}
-{% modal-body %}

--- a/pages/domains/domains_election.md
+++ b/pages/domains/domains_election.md
@@ -78,6 +78,3 @@ Read more about [CISA election security support](https://www.cisa.gov/election-s
 ## Request your .gov domain
 
 [Read about what you’ll need to request your .gov domain](../before/).
-
-{% modal-trigger--button %}
-{% modal-body %}

--- a/pages/domains/domains_eligibility.md
+++ b/pages/domains/domains_eligibility.md
@@ -40,5 +40,3 @@ Read more about senior officials for your organization:
 
 If you’re ready to request your .gov domain, then get started. You don’t have to complete the process in one session. You can save what you enter and come back to it when you’re ready.
 
-{% modal-trigger--button %}
-{% modal-body %}

--- a/pages/domains/domains_index.md
+++ b/pages/domains/domains_index.md
@@ -14,5 +14,4 @@ eleventyNavigation:
   title: Domains
   order: 1
 ---
-{% modal-trigger--button %}
-{% modal-body %}
+

--- a/pages/help/help_domain-requests.md
+++ b/pages/help/help_domain-requests.md
@@ -18,9 +18,6 @@ eleventyNavigation:
 ## Request your .gov domain
 If you’re ready to request your .gov domain, then get started. You don’t have to complete the process in one session. You can save what you enter and come back to it when you’re ready.
 
-{% modal-trigger--button %}
-{% modal-body %}
-
 ## Before you request your .gov domain
 
 You must be a government employee, or be working on behalf of the government, to request a .gov domain. 


### PR DESCRIPTION
https://github.com/cisagov/manage.get.gov/pull/4767 removed the request buttons from the registrar. This removes the buttons (just the buttons) to start a request from get.gov. 

This leaves some text slightly dangling. Once the shutdown ends, we can re-evaluate what we want to put back.