### PR TITLE
Fix typo ("cateogry" -> "category")

### DIFF
--- a/_includes/layouts/blog.html
+++ b/_includes/layouts/blog.html
@@ -67,7 +67,7 @@ title: Blog
       </ul>
     </div>
 
-    <article aria-label="Blog description and cateogry tags" 
+    <article aria-label="Blog description and category tags" 
              class="tablet:grid-offset-1 tablet:grid-col-fill 
                     margin-top-4 padding-right-4 
                     usa-prose"


### PR DESCRIPTION
## Changes

<!-- What was added, updated, or removed in this PR. -->
- Swapped two letters "cateogry" -> "category"