### PR TITLE
Fix link text and header in updated member management text

### DIFF
--- a/pages/help/help_member-management.md
+++ b/pages/help/help_member-management.md
@@ -24,7 +24,7 @@ eleventyNavigation:
 * [Understanding enterprise mode roles and permissions](#understanding-enterprise-mode-roles-and-permissions)
 * [Add new members to your organization](#add-new-members-to-your-organization)
 * [Manage existing members](#manage-existing-members)
-* [Manage domain assignments for members or org admins](#manage-domain-assignments-for-a-member)
+* [Manage domain assignments for members or org admins](#manage-domain-assignments-for-members-or-org-admins)
 
 ## Understanding enterprise mode roles and permissions
 
@@ -99,7 +99,7 @@ If you’re not an org admin, you won’t be able to view the Members page. Basi
 4. Click the three dots beside the “Manage” link to view “More options.”  
 5. Click “Remove member” or “Cancel invitation.”
 
-## Manage domain assignments for a member
+## Manage domain assignments for members or org admins
 
 Only org admins can manage domain assignments. Basic members who have been granted the ability to "view all member permissions" can view, but not edit, domain assignments.
 


### PR DESCRIPTION
This PR makes a small addition to #551, bringing the table-of-contents anchor in line with linked-to text.