### PR TITLE
Small fixes

### DIFF
--- a/_includes/content-blocks/eligibility_org_types.html
+++ b/_includes/content-blocks/eligibility_org_types.html
@@ -32,9 +32,9 @@
 
     <h4>Other legislative branch agencies or commissions</h4>
     
-    <p>Domain requests from legislative branch agencies must come from the agency’s head or CIO. A request must be submitted by the agency’s <a href="{{ '/help/member-management/' | url }}#understanding-enterprise-mode-roles-and-permissions" class="usa-link">organization admin</a> or another person with request permissions.</p>
+    <p>Domain requests from legislative branch agencies must be authorized by the agency’s head or CIO. A request must be submitted by the agency’s <a href="{{ '/help/member-management/' | url }}#understanding-enterprise-mode-roles-and-permissions" class="usa-link">organization admin</a> or another person with request permissions.</p>
     
-    <p>Domain requests from legislative commissions must come from the head of the commission, or the head or CIO of the parent agency, if there is one. A request must be submitted by the commission’s <a href="{{ '/help/member-management/' | url }}#understanding-enterprise-mode-roles-and-permissions" class="usa-link">organization admin</a> or another person with request permissions.</p>
+    <p>Domain requests from legislative commissions must be authorized by the head of the commission, or the head or CIO of the parent agency, if there is one. A request must be submitted by the commission’s <a href="{{ '/help/member-management/' | url }}#understanding-enterprise-mode-roles-and-permissions" class="usa-link">organization admin</a> or another person with request permissions.</p>
   </div>
 
   <h3 class="usa-accordion__heading">

--- a/pages/domains/domains_before.md
+++ b/pages/domains/domains_before.md
@@ -65,4 +65,4 @@ Read more about [domain management.](../../help/domain-management/)
 
 ## Start your domain request
 
-Ready to request a .gov domain? Get started! You don’t have to complete the process in one session. You can save your progress and come back to it when you’re ready. 
+Ready to request a .gov domain? [Get started](../../domains)! You don’t have to complete the process in one session. You can save your progress and come back to it when you’re ready. 

--- a/pages/domains/domains_eligibility.md
+++ b/pages/domains/domains_eligibility.md
@@ -38,5 +38,4 @@ Read more about senior officials for your organization:
 
 ## Request your .gov domain
 
-If you’re ready to request your .gov domain, then get started. You don’t have to complete the process in one session. You can save what you enter and come back to it when you’re ready.
-
+If you’re ready to request your .gov domain, then [get started](../../domains). You don’t have to complete the process in one session. You can save what you enter and come back to it when you’re ready.

--- a/pages/help/help_domain-requests.md
+++ b/pages/help/help_domain-requests.md
@@ -16,7 +16,7 @@ eleventyNavigation:
 - [Withdraw your domain request](#withdraw-your-domain-request)
 
 ## Request your .gov domain
-If you’re ready to request your .gov domain, then get started. You don’t have to complete the process in one session. You can save what you enter and come back to it when you’re ready.
+If you’re ready to request your .gov domain, then [get started](../../domains/). You don’t have to complete the process in one session. You can save what you enter and come back to it when you’re ready.
 
 ## Before you request your .gov domain
 


### PR DESCRIPTION
This change fixes some legacy language on the eligibility page about legislative branch orgs, making it clear that a request must be authorized by a SO, not "come from" them.

It also links to the request form's landing page in a few places that used to link directly to start a new request. We removed that so there's only a single entry point to the request form (so it's easier to turn off when necessary). We've heard some were confused about where to go.

Google Docs have been updated:
* [Domains _ Eligibility for .gov domains](https://docs.google.com/document/d/1Q96zwCNSzTBTEUX7fJXiYx2wdhqN_ijvTkHufwi01oo/edit?tab=t.0)
* [Domains _ Before you request a .gov domain](https://docs.google.com/document/d/1PIJ_7JGoTIZkV4BrSBiZX7f8mpWsAY4UMaqHMn61dzQ/edit?tab=t.0)
* [Help _ Domain requests section](https://docs.google.com/document/d/1U7MLSXvDJsAxfEzPdKXoy6-wBL9IKynJ9JLDHTrEjxY/edit?tab=t.0)